### PR TITLE
Clarify Groq per-model RPD limits and OpenRouter credit tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Third-party platforms that host open-weight models from various sources.
 - [Cerebras](https://cloud.cerebras.ai/) 🇺🇸 - Llama 3.3 70B, Qwen3 235B, GPT-OSS-120B +3 more. 30 RPM, 14,400 RPD.
 - [Cloudflare Workers AI](https://dash.cloudflare.com/profile/api-tokens) 🇺🇸 - Llama 3.3 70B, Qwen QwQ 32B +47 more. 10K neurons/day.
 - [GitHub Models](https://github.com/marketplace/models) 🇺🇸 - GPT-4o, Llama 3.3 70B, DeepSeek-R1 +more. 10-15 RPM, 50-150 RPD.
-- [Groq](https://console.groq.com/keys) 🇺🇸 - Llama 3.3 70B, Llama 4 Scout, Kimi K2 +17 more. 30 RPM, 14,400 RPD.
+- [Groq](https://console.groq.com/keys) 🇺🇸 - Llama 3.3 70B, Llama 4 Scout, Kimi K2 +17 more. 30 RPM, 1K RPD (14,400 for Llama 3.1 8B). [^3]
 - [Hugging Face](https://huggingface.co/settings/tokens) 🇺🇸 - Llama 3.3 70B, Qwen2.5 72B, Mistral 7B +many more. $0.10/mo in free credits.
 - [Kluster AI](https://platform.kluster.ai/apikeys) 🇺🇸 - DeepSeek-R1, Llama 4 Maverick, Qwen3-235B +2 more. Limits undocumented.
 - [LLM7.io](https://token.llm7.io) 🇬🇧 - DeepSeek R1, Flash-Lite, Qwen2.5 Coder +27 more. 30 RPM (120 with token).
 - [NVIDIA NIM](https://build.nvidia.com/explore/discover) 🇺🇸 - Llama 3.3 70B, Mistral Large, Qwen3 235B +more. 40 RPM.
 - [Ollama Cloud](https://ollama.com/settings/keys) 🇺🇸 - DeepSeek-V3.2, Qwen3.5, Kimi-K2.5 +17 more. 1 concurrent model, light usage. [^2]
-- [OpenRouter](https://openrouter.ai/keys) 🇺🇸 - DeepSeek R1, Llama 3.3 70B, GPT-OSS-120B +29 more. 20 RPM, 50 RPD.
+- [OpenRouter](https://openrouter.ai/keys) 🇺🇸 - DeepSeek R1, Llama 3.3 70B, GPT-OSS-120B +29 more. 20 RPM, 50 RPD (1K with $10+ in purchased credits). [^4]
 
 ## Contributing
 
@@ -54,3 +54,5 @@ Know a free tier that's missing? [Open a PR](contributing.md). Include the provi
 - Each link points to the provider's API key page.
 - [^1]: Free tier not available in the EU, UK, or Switzerland ([available regions](https://ai.google.dev/gemini-api/docs/available-regions)).
 - [^2]: Ollama Cloud measures usage by GPU time, not tokens or requests. Free tier described as "light usage" with session limits resetting every 5 hours and weekly limits every 7 days. Pro (50x more) and Max (250x more) plans available. Not OpenAI SDK-compatible; uses [Ollama API](https://docs.ollama.com/cloud).
+- [^3]: 14,400 RPD only applies to Llama 3.1 8B Instant. Most other models (Llama 3.3 70B, Llama 4 Scout, Kimi K2, etc.) are limited to 1,000 RPD ([rate limits](https://console.groq.com/docs/rate-limits)).
+- [^4]: Free models default to 50 RPD. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order.


### PR DESCRIPTION
## Summary

- **Groq**: The README previously listed 14,400 RPD as the blanket limit, but that only applies to Llama 3.1 8B Instant. Most models (Llama 3.3 70B, Llama 4 Scout, Kimi K2, etc.) are capped at 1,000 RPD. Updated the entry and added a footnote with a link to Groq's rate limits docs.
- **OpenRouter**: Added detail that the 50 RPD base limit increases to 1,000 RPD with a one-time $10+ credit purchase. Also added a footnote mentioning the Free Models Router (`openrouter/free`) and model fallback features for chaining models in priority order.

Both corrections were verified against official documentation and corroborated by community reports.

## Sources

- [Groq rate limits](https://console.groq.com/docs/rate-limits)
- [OpenRouter rate limits (Zendesk)](https://openrouter.zendesk.com/hc/en-us/articles/39501163636379)
- [OpenRouter policy analysis (Oreate AI)](https://www.oreateai.com/blog/indepth-analysis-of-openrouters-free-policy-adjustments-daily-quota-changes-and-response-strategies/d450d1aa56b67882c0100e68510fac55)

## Test plan

- [ ] Verify footnote links render correctly in GitHub markdown
- [ ] Confirm footnote numbering is sequential ([^3], [^4])

https://claude.ai/code/session_016mttV9JhV1qrqw7HeCVaMp