### PR TITLE
Add AIHubMix as inference provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ APIs run by the companies that train or fine-tune the models themselves.
 
 Third-party platforms that host open-weight models from various sources.
 
+- [AIHubMix](https://console.aihubmix.com/token) 🇺🇸 - GPT-4o, Gemini 3.1 Flash, GLM-5 +17 more. 5 RPM, 500 RPD.
 - [Cerebras](https://cloud.cerebras.ai/) 🇺🇸 - Llama 3.3 70B, Qwen3 235B, GPT-OSS-120B +3 more. 30 RPM, 14,400 RPD.
 - [Cloudflare Workers AI](https://dash.cloudflare.com/profile/api-tokens) 🇺🇸 - Llama 3.3 70B, Qwen QwQ 32B +47 more. 10K neurons/day.
 - [GitHub Models](https://github.com/marketplace/models) 🇺🇸 - GPT-4o, Llama 3.3 70B, DeepSeek-R1 +more. 10-15 RPM, 50-150 RPD.

--- a/free-llm-apis/references/inference-providers.md
+++ b/free-llm-apis/references/inference-providers.md
@@ -2,6 +2,43 @@
 
 Third-party platforms that host open-weight models from various sources.
 
+## AIHubMix
+
+**Models:** GPT-4o, Gemini 3.1 Flash, GLM-5 +17 more
+**Limits:** 5 RPM, 500 RPD
+
+### Get your API key
+
+1. Go to [AIHubMix Console](https://console.aihubmix.com/token).
+2. Create an account or sign in.
+3. Click "Create Token."
+4. Copy the token.
+
+### Usage example
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="YOUR_AIHUBMIX_API_KEY",
+    base_url="https://aihubmix.com/v1/"
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o-free",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.choices[0].message.content)
+```
+
+### Environment variable
+
+```bash
+export AIHUBMIX_API_KEY="your-key-here"
+```
+
+---
+
 ## GitHub Models
 
 **Models:** GPT-4o, Llama 3.3 70B, DeepSeek-R1 +more


### PR DESCRIPTION
## Provider

AIHubMix — https://console.aihubmix.com/token 🇺🇸

## Checklist

- [x] Permanent free tier (no trial credits, no expiry)
- [x] No credit card required
- [x] REST API with OpenAI-compatible endpoint

## Details

- Free models: 20, including GPT-4o, Gemini 3.1 Flash, GLM-5, Minimax M2.7
- Rate limits: 5 RPM, 500 RPD
- Docs: https://aihubmix.com/model/coding-glm-5-free