### PR TITLE
Add ContextWire to inference providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Third-party platforms that host open-weight models from various sources.
 
 - [Cerebras](https://cloud.cerebras.ai/) 🇺🇸 - Llama 3.3 70B, Qwen3 235B, GPT-OSS-120B +3 more. 30 RPM, 14,400 RPD.
 - [Cloudflare Workers AI](https://dash.cloudflare.com/profile/api-tokens) 🇺🇸 - Llama 3.3 70B, Qwen QwQ 32B +47 more. 10K neurons/day.
+- [ContextWire](https://contextwire.dev/docs.html) 🇺🇸 - Search API for AI agents with 105 engines, 22 profiles, MCP server. 1K queries/mo free ([docs](https://contextwire.dev/docs.html)).
 - [GitHub Models](https://github.com/marketplace/models) 🇺🇸 - GPT-4o, Llama 3.3 70B, DeepSeek-R1 +more. 10-15 RPM, 50-150 RPD.
 - [Groq](https://console.groq.com/keys) 🇺🇸 - Llama 3.3 70B, Llama 4 Scout, Kimi K2 +17 more. 30 RPM, 1K RPD (14,400 for Llama 3.1 8B). [^3]
 - [Hugging Face](https://huggingface.co/settings/tokens) 🇺🇸 - Llama 3.3 70B, Qwen2.5 72B, Mistral 7B +many more. $0.10/mo in free credits.


### PR DESCRIPTION
Adds ContextWire to the Inference providers section.

ContextWire is a free search API for AI agents with 105 search engines, 22 specialized search profiles, an MCP server, and 94.3% SimpleQA accuracy. It offers 1,000 free queries per month with API key authentication (no credit card required).

- Website: https://contextwire.dev
- API Docs: https://contextwire.dev/docs.html
- GitHub: https://github.com/keptlive/contextwire-mcp
- OpenAPI spec: https://contextwire.dev/openapi.json