### PR TITLE
Add SiliconFlow to third-party platforms list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Third-party platforms that host open-weight models from various sources.
 - [NVIDIA NIM](https://build.nvidia.com/explore/discover) 🇺🇸 - Llama 3.3 70B, Mistral Large, Qwen3 235B +more. 40 RPM.
 - [Ollama Cloud](https://ollama.com/settings/keys) 🇺🇸 - DeepSeek-V3.2, Qwen3.5, Kimi-K2.5 +17 more. 1 concurrent model, light usage. [^2]
 - [OpenRouter](https://openrouter.ai/keys) 🇺🇸 - DeepSeek R1, Llama 3.3 70B, GPT-OSS-120B +29 more. 20 RPM, 50 RPD (1K with $10+ in purchased credits). [^4]
+- [SiliconFlow](https://cloud.siliconflow.cn/account/ak) 🇨🇳 - Qwen3-8B, DeepSeek-R1-Distill-Qwen-7B, GLM-4.1V-9B-Thinking +10 more. 1K RPM, 50K TPM.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
Added SiliconFlow to the README's list of third-party platforms that host open-weight models.

## Changes
- Added SiliconFlow entry to the platforms section with:
  - Link to SiliconFlow's API key management page
  - China region indicator (🇨🇳)
  - List of available models: Qwen3-8B, DeepSeek-R1-Distill-Qwen-7B, GLM-4.1V-9B-Thinking, and 10+ more
  - Rate limits: 1K RPM (requests per minute) and 50K TPM (tokens per minute)

## Details
SiliconFlow is positioned as an additional option for users seeking access to open-weight models with competitive rate limits, complementing the existing platforms like NVIDIA NIM, Ollama Cloud, and OpenRouter.

https://claude.ai/code/session_01FdbHvSNkafj7EAJLSi9YEY