### PR TITLE
Add Base URL for all providers and fix Kilo Code model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ APIs run by the companies that train or fine-tune the models themselves.
 
 Free "Trial" API key, no credit card. 1,000 API calls/month. Non-commercial use only.
 
+Base URL: `https://api.cohere.com/v2`
+
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
 | Command A (111B) | 256K | 4K | Text | 20 RPM |
@@ -39,6 +41,8 @@ Free "Trial" API key, no credit card. 1,000 API calls/month. Non-commercial use 
 
 Free tier unavailable in EU/UK/Switzerland. Free-tier prompts may be used by Google to improve products. [^1]
 
+Base URL: `https://generativelanguage.googleapis.com/v1beta`
+
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
 | Gemini 2.5 Flash | 1M | 65K | Text + Image + Audio + Video | 10 RPM, 250 RPD |
@@ -47,6 +51,8 @@ Free tier unavailable in EU/UK/Switzerland. Free-tier prompts may be used by Goo
 ### [Mistral AI](https://console.mistral.ai/api-keys) 🇫🇷
 
 Free "Experiment" plan, no credit card. ~1B tokens/month.
+
+Base URL: `https://api.mistral.ai/v1`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -60,6 +66,8 @@ Free "Experiment" plan, no credit card. ~1B tokens/month.
 ### [Z AI (Zhipu AI)](https://open.bigmodel.cn/usercenter/apikeys) 🇨🇳
 
 Permanent free models, no credit card required.
+
+Base URL: `https://open.bigmodel.cn/api/paas/v4`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -75,6 +83,8 @@ Third-party platforms that host open-weight models from various sources.
 
 Free tier, no credit card. Ultra-fast inference (~2,600 tok/s). 1M tokens/day cap.
 
+Base URL: `https://api.cerebras.ai/v1`
+
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
 | llama3.1-8b | 128K (8K on free) | 8K | Text | 30 RPM, 14,400 RPD, 1M TPD |
@@ -85,6 +95,8 @@ Free tier, no credit card. Ultra-fast inference (~2,600 tok/s). 1M tokens/day ca
 ### [Cloudflare Workers AI](https://dash.cloudflare.com/profile/api-tokens) 🇺🇸
 
 10,000 Neurons/day free. 50+ models available on free tier.
+
+Base URL: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -100,7 +112,9 @@ Free tier, no credit card. Ultra-fast inference (~2,600 tok/s). 1M tokens/day ca
 
 ### [GitHub Models](https://github.com/marketplace/models) 🇺🇸
 
-Free prototyping for all GitHub users. Per-request limits: 8K in / 4K out.
+Free prototyping for all GitHub users. 45+ models. Per-request limits (8K in / 4K out).
+
+Base URL: `https://models.inference.ai.azure.com`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -120,6 +134,8 @@ Free prototyping for all GitHub users. Per-request limits: 8K in / 4K out.
 
 Free tier, no credit card. Ultra-fast LPU inference. [^2]
 
+Base URL: `https://api.groq.com/openai/v1`
+
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
 | llama-3.3-70b-versatile | 131K | 32K | Text | 30 RPM, 14,400 RPD |
@@ -135,7 +151,9 @@ Free tier, no credit card. Ultra-fast LPU inference. [^2]
 
 ### [Hugging Face](https://huggingface.co/settings/tokens) 🇺🇸
 
-Free Serverless Inference API + ~$0.10/month free credits.
+Free Serverless Inference API + ~$0.10/month free credits. Thousands of models.
+
+Base URL: `https://api-inference.huggingface.co/models`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -148,26 +166,23 @@ Free Serverless Inference API + ~$0.10/month free credits.
 
 ### [Kilo Code](https://kilo.ai) 🇺🇸
 
-Free models with no credit card required. Base URL: `https://api.kilo.ai/api/gateway`. [^5]
+Free models with no credit card required. `kilo-auto/free` auto-router routes to minimax/minimax-m2.5:free (80%) and stepfun/step-3.5-flash:free (20%). [^5]
+
+Base URL: `https://api.kilo.ai/api/gateway`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
-| qwen/qwen3.6-plus-preview:free | 1M | 32K | Text + Image + Video | ~200 req/hr |
+| bytedance-seed/dola-seed-2.0-pro:free | — | — | Text | ~200 req/hr |
+| x-ai/grok-code-fast-1:optimized:free | — | — | Text (code) | ~200 req/hr |
 | nvidia/nemotron-3-super-120b-a12b:free | 262K | 32K | Text | ~200 req/hr |
-| stepfun/step-3.5-flash:free | 256K | 65K | Text | ~200 req/hr |
-| corethink:free | ~78K | ~8K | Text | ~200 req/hr |
-| minimax/minimax-m2.5:free | 196K | 196K | Text | ~200 req/hr |
-| arcee-ai/trinity-large-preview:free | 128K | ~32K | Text | ~200 req/hr |
-| kwaipilot/kat-coder-pro:free | 262K | 128K | Text (code) | ~200 req/hr |
-| qwen/qwen3-coder:free | 262K | 262K | Text (code) | ~200 req/hr |
-| google/gemma-4-31b-it:free | 262K | — | Multimodal | ~200 req/hr |
-| deepseek/deepseek-r1-0528:free | — | — | Text (reasoning) | ~200 req/hr |
-| meta-llama/llama-3.3-70b-instruct:free | — | — | Text | ~200 req/hr |
-| + ~18 more rotating free models | Varies | Varies | Text / Image | ~200 req/hr |
+| arcee-ai/trinity-large-thinking:free | — | — | Text (reasoning) | ~200 req/hr |
+| openrouter/free | Varies | Varies | Text | ~200 req/hr |
 
 ### [LLM7.io](https://token.llm7.io) 🇬🇧
 
-Zero-friction API gateway. No registration needed for basic access.
+Zero-friction API gateway. No registration needed for basic access. 30+ models.
+
+Base URL: `https://api.llm7.io/v1`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -181,7 +196,9 @@ Zero-friction API gateway. No registration needed for basic access.
 
 ### [NVIDIA NIM](https://build.nvidia.com/explore/discover) 🇺🇸
 
-Free with NVIDIA Developer Program membership. No daily token cap.
+Free with NVIDIA Developer Program membership. 100+ models. No daily token cap.
+
+Base URL: `https://integrate.api.nvidia.com/v1`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -199,7 +216,9 @@ Free with NVIDIA Developer Program membership. No daily token cap.
 
 ### [Ollama Cloud](https://ollama.com/settings/keys) 🇺🇸
 
-Free tier with qualitative usage limits.
+Free tier with qualitative usage limits. 400+ models from Ollama library. Not OpenAI SDK-compatible; uses [Ollama API](https://docs.ollama.com/cloud). [^3]
+
+Base URL: `https://api.ollama.com`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -213,6 +232,8 @@ Free tier with qualitative usage limits.
 ### [OpenRouter](https://openrouter.ai/keys) 🇺🇸
 
 35+ free models (marked with `:free` suffix). OpenAI SDK-compatible. [^4]
+
+Base URL: `https://openrouter.ai/api/v1`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -233,6 +254,8 @@ Free tier with qualitative usage limits.
 ### [SiliconFlow](https://cloud.siliconflow.cn/account/ak) 🇨🇳
 
 Free tier with 14 CNY signup credits. Permanently free models available.
+
+Base URL: `https://api.siliconflow.cn/v1`
 
 | Model Name | Context | Max Output | Modality | Rate Limit |
 |---|---|---|---|---|
@@ -267,4 +290,4 @@ Know a free tier that's missing? [Open a PR](contributing.md). Include the provi
 [^2]: Groq rate limits vary by model. Llama 4 Maverick is limited to 500 RPD. Most other models get 14,400 RPD ([rate limits](https://console.groq.com/docs/rate-limits)).
 [^3]: Ollama Cloud measures usage by GPU time, not tokens or requests. Free tier described as "light usage" with session limits resetting every 5 hours and weekly limits every 7 days. Pro (50x more) and Max (250x more) plans available. Not OpenAI SDK-compatible; uses [Ollama API](https://docs.ollama.com/cloud).
 [^4]: Free models default to 200 RPD. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order.
-[^5]: Kilo Code free model list is dynamic and rotates based on partnerships. Free models log prompts for improvement. Auto-router available: `kilo-auto/free`.
+[^5]: Kilo Code free model list may change over time. nvidia/nemotron-3-super-120b-a12b:free is for trial use only — prompts are logged by NVIDIA. Auto-router `kilo-auto/free` routes to minimax/minimax-m2.5:free (80%) and stepfun/step-3.5-flash:free (20%).

--- a/data.json
+++ b/data.json
@@ -7,6 +7,7 @@
       "country": "CA",
       "flag": "🇨🇦",
       "url": "https://dashboard.cohere.com/api-keys",
+      "baseUrl": "https://api.cohere.com/v2",
       "description": "Free \"Trial\" API key, no credit card. 1,000 API calls/month. Non-commercial use only.",
       "footnoteRef": null,
       "models": [
@@ -60,6 +61,7 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://aistudio.google.com/app/apikey",
+      "baseUrl": "https://generativelanguage.googleapis.com/v1beta",
       "description": "Free tier unavailable in EU/UK/Switzerland. Free-tier prompts may be used by Google to improve products.",
       "footnoteRef": 1,
       "models": [
@@ -85,6 +87,7 @@
       "country": "FR",
       "flag": "🇫🇷",
       "url": "https://console.mistral.ai/api-keys",
+      "baseUrl": "https://api.mistral.ai/v1",
       "description": "Free \"Experiment\" plan, no credit card. ~1B tokens/month.",
       "footnoteRef": null,
       "models": [
@@ -138,6 +141,7 @@
       "country": "CN",
       "flag": "🇨🇳",
       "url": "https://open.bigmodel.cn/usercenter/apikeys",
+      "baseUrl": "https://open.bigmodel.cn/api/paas/v4",
       "description": "Permanent free models, no credit card required.",
       "footnoteRef": null,
       "models": [
@@ -170,6 +174,7 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://cloud.cerebras.ai/",
+      "baseUrl": "https://api.cerebras.ai/v1",
       "description": "Free tier, no credit card. Ultra-fast inference (~2,600 tok/s). 1M tokens/day cap.",
       "footnoteRef": null,
       "models": [
@@ -209,6 +214,7 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://dash.cloudflare.com/profile/api-tokens",
+      "baseUrl": "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run",
       "description": "10,000 Neurons/day free. 50+ models available on free tier.",
       "footnoteRef": null,
       "models": [
@@ -283,6 +289,7 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://github.com/marketplace/models",
+      "baseUrl": "https://models.inference.ai.azure.com",
       "description": "Free prototyping for all GitHub users. 45+ models. Per-request limits (8K in / 4K out).",
       "footnoteRef": null,
       "models": [
@@ -371,6 +378,7 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://console.groq.com/keys",
+      "baseUrl": "https://api.groq.com/openai/v1",
       "description": "Free tier, no credit card. Ultra-fast LPU inference.",
       "footnoteRef": 2,
       "models": [
@@ -452,6 +460,7 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://huggingface.co/settings/tokens",
+      "baseUrl": "https://api-inference.huggingface.co/models",
       "description": "Free Serverless Inference API + ~$0.10/month free credits. Thousands of models.",
       "footnoteRef": null,
       "models": [
@@ -505,14 +514,22 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://kilo.ai",
-      "description": "Free models with no credit card required. ~29 rotating free models. Base URL: `https://api.kilo.ai/api/gateway`.",
+      "baseUrl": "https://api.kilo.ai/api/gateway",
+      "description": "Free models with no credit card required. `kilo-auto/free` auto-router routes to minimax/minimax-m2.5:free (80%) and stepfun/step-3.5-flash:free (20%).",
       "footnoteRef": 5,
       "models": [
         {
-          "name": "qwen/qwen3.6-plus-preview:free",
-          "context": "1M",
-          "maxOutput": "32K",
-          "modality": "Text + Image + Video",
+          "name": "bytedance-seed/dola-seed-2.0-pro:free",
+          "context": "—",
+          "maxOutput": "—",
+          "modality": "Text",
+          "rateLimit": "~200 req/hr"
+        },
+        {
+          "name": "x-ai/grok-code-fast-1:optimized:free",
+          "context": "—",
+          "maxOutput": "—",
+          "modality": "Text (code)",
           "rateLimit": "~200 req/hr"
         },
         {
@@ -523,73 +540,17 @@
           "rateLimit": "~200 req/hr"
         },
         {
-          "name": "stepfun/step-3.5-flash:free",
-          "context": "256K",
-          "maxOutput": "65K",
-          "modality": "Text",
-          "rateLimit": "~200 req/hr"
-        },
-        {
-          "name": "corethink:free",
-          "context": "~78K",
-          "maxOutput": "~8K",
-          "modality": "Text",
-          "rateLimit": "~200 req/hr"
-        },
-        {
-          "name": "minimax/minimax-m2.5:free",
-          "context": "196K",
-          "maxOutput": "196K",
-          "modality": "Text",
-          "rateLimit": "~200 req/hr"
-        },
-        {
-          "name": "arcee-ai/trinity-large-preview:free",
-          "context": "128K",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "~200 req/hr"
-        },
-        {
-          "name": "kwaipilot/kat-coder-pro:free",
-          "context": "262K",
-          "maxOutput": "128K",
-          "modality": "Text (code)",
-          "rateLimit": "~200 req/hr"
-        },
-        {
-          "name": "qwen/qwen3-coder:free",
-          "context": "262K",
-          "maxOutput": "262K",
-          "modality": "Text (code)",
-          "rateLimit": "~200 req/hr"
-        },
-        {
-          "name": "google/gemma-4-31b-it:free",
-          "context": "262K",
-          "maxOutput": "—",
-          "modality": "Multimodal",
-          "rateLimit": "~200 req/hr"
-        },
-        {
-          "name": "deepseek/deepseek-r1-0528:free",
+          "name": "arcee-ai/trinity-large-thinking:free",
           "context": "—",
           "maxOutput": "—",
           "modality": "Text (reasoning)",
           "rateLimit": "~200 req/hr"
         },
         {
-          "name": "meta-llama/llama-3.3-70b-instruct:free",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Text",
-          "rateLimit": "~200 req/hr"
-        },
-        {
-          "name": "+ ~18 more rotating free models",
+          "name": "openrouter/free",
           "context": "Varies",
           "maxOutput": "Varies",
-          "modality": "Text / Image",
+          "modality": "Text",
           "rateLimit": "~200 req/hr"
         }
       ]
@@ -600,6 +561,7 @@
       "country": "GB",
       "flag": "🇬🇧",
       "url": "https://token.llm7.io",
+      "baseUrl": "https://api.llm7.io/v1",
       "description": "Zero-friction API gateway. No registration needed for basic access. 30+ models.",
       "footnoteRef": null,
       "models": [
@@ -660,6 +622,7 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://build.nvidia.com/explore/discover",
+      "baseUrl": "https://integrate.api.nvidia.com/v1",
       "description": "Free with NVIDIA Developer Program membership. 100+ models. No daily token cap.",
       "footnoteRef": null,
       "models": [
@@ -748,6 +711,7 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://ollama.com/settings/keys",
+      "baseUrl": "https://api.ollama.com",
       "description": "Free tier with qualitative usage limits. 400+ models from Ollama library. Not OpenAI SDK-compatible; uses [Ollama API](https://docs.ollama.com/cloud).",
       "footnoteRef": 3,
       "models": [
@@ -801,6 +765,7 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://openrouter.ai/keys",
+      "baseUrl": "https://openrouter.ai/api/v1",
       "description": "35+ free models (marked with `:free` suffix). OpenAI SDK-compatible.",
       "footnoteRef": 4,
       "models": [
@@ -903,6 +868,7 @@
       "country": "CN",
       "flag": "🇨🇳",
       "url": "https://cloud.siliconflow.cn/account/ak",
+      "baseUrl": "https://api.siliconflow.cn/v1",
       "description": "Free tier with 14 CNY signup credits. Permanently free models available.",
       "footnoteRef": null,
       "models": [
@@ -977,7 +943,7 @@
     },
     {
       "id": 5,
-      "text": "Kilo Code free model list is dynamic and rotates based on partnerships. Free models log prompts for improvement. Auto-router available: `kilo-auto/free`."
+      "text": "Kilo Code free model list may change over time. nvidia/nemotron-3-super-120b-a12b:free is for trial use only — prompts are logged by NVIDIA. Auto-router `kilo-auto/free` routes to minimax/minimax-m2.5:free (80%) and stepfun/step-3.5-flash:free (20%)."
     }
   ],
   "glossary": [

--- a/scripts/generate-readme.js
+++ b/scripts/generate-readme.js
@@ -36,13 +36,16 @@ function buildProviderSection(provider) {
 	const desc = provider.footnoteRef != null
 		? `${provider.description} [^${provider.footnoteRef}]`
 		: provider.description;
-	return [
+	const parts = [
 		`### [${provider.name}](${provider.url}) ${provider.flag}`,
 		'',
 		desc,
-		'',
-		buildTable(provider.models),
-	].join('\n');
+	];
+	if (provider.baseUrl != null) {
+		parts.push('', `Base URL: \`${provider.baseUrl}\``);
+	}
+	parts.push('', buildTable(provider.models));
+	return parts.join('\n');
 }
 
 const providerAPIs = data.providers


### PR DESCRIPTION
## Summary

- Add `baseUrl` field to every provider in `data.json` (15 providers total)
- Update `scripts/generate-readme.js` to render a **Base URL** line between the description and the model table for each provider (skipped if `null`)
- Fix Kilo Code: replace ~11 rotating models with the 5 official free models from their docs; update description to document the `kilo-auto/free` auto-router routing (minimax/minimax-m2.5:free 80% / stepfun/step-3.5-flash:free 20%); update footnote accordingly
- Regenerate `README.md`

## Test plan

- [x] `node scripts/generate-readme.js` runs without errors
- [x] Every provider section in README.md now includes a `Base URL: \`...\`` line between description and table
- [x] Kilo Code section shows exactly 5 models