### PR TITLE
feat: add model API IDs

### DIFF
--- a/data.json
+++ b/data.json
@@ -12,6 +12,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "command-a-03-2025",
           "name": "Command A (111B)",
           "context": "256K",
           "maxOutput": "4K",
@@ -19,6 +20,7 @@
           "rateLimit": "20 RPM"
         },
         {
+          "id": "command-r-plus",
           "name": "Command R+",
           "context": "128K",
           "maxOutput": "4K",
@@ -26,6 +28,7 @@
           "rateLimit": "20 RPM"
         },
         {
+          "id": "command-r",
           "name": "Command R",
           "context": "128K",
           "maxOutput": "4K",
@@ -33,6 +36,7 @@
           "rateLimit": "20 RPM"
         },
         {
+          "id": "command-r7b",
           "name": "Command R7B",
           "context": "128K",
           "maxOutput": "4K",
@@ -40,6 +44,7 @@
           "rateLimit": "20 RPM"
         },
         {
+          "id": "embed-v4.0",
           "name": "Embed 4",
           "context": "—",
           "maxOutput": "—",
@@ -47,6 +52,7 @@
           "rateLimit": "2,000 inputs/min"
         },
         {
+          "id": "rerank-v3.5",
           "name": "Rerank 3.5",
           "context": "—",
           "maxOutput": "—",
@@ -66,6 +72,7 @@
       "footnoteRef": 1,
       "models": [
         {
+          "id": "gemini-2.5-flash",
           "name": "Gemini 2.5 Flash",
           "context": "1M",
           "maxOutput": "65K",
@@ -73,6 +80,7 @@
           "rateLimit": "10 RPM, 250 RPD"
         },
         {
+          "id": "gemini-2.5-flash-lite",
           "name": "Gemini 2.5 Flash-Lite",
           "context": "1M",
           "maxOutput": "65K",
@@ -92,6 +100,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "mistral-small-2503",
           "name": "Mistral Small 4",
           "context": "256K",
           "maxOutput": "256K",
@@ -99,6 +108,7 @@
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
+          "id": "mistral-medium-2505",
           "name": "Mistral Medium 3",
           "context": "128K",
           "maxOutput": "128K",
@@ -106,6 +116,7 @@
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
+          "id": "mistral-large-latest",
           "name": "Mistral Large 3",
           "context": "256K",
           "maxOutput": "256K",
@@ -113,6 +124,7 @@
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
+          "id": "open-mistral-nemo",
           "name": "Mistral Nemo (12B)",
           "context": "128K",
           "maxOutput": "128K",
@@ -120,6 +132,7 @@
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
+          "id": "codestral-latest",
           "name": "Codestral",
           "context": "256K",
           "maxOutput": "256K",
@@ -127,6 +140,7 @@
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
+          "id": "pixtral-large-latest",
           "name": "Pixtral Large",
           "context": "128K",
           "maxOutput": "128K",
@@ -146,6 +160,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "glm-4.7-flash",
           "name": "GLM-4.7-Flash",
           "context": "200K",
           "maxOutput": "128K",
@@ -153,6 +168,7 @@
           "rateLimit": "1 concurrent request"
         },
         {
+          "id": "glm-4.5-flash",
           "name": "GLM-4.5-Flash",
           "context": "128K",
           "maxOutput": "~8K",
@@ -160,6 +176,7 @@
           "rateLimit": "1 concurrent request"
         },
         {
+          "id": "glm-4.6v-flash",
           "name": "GLM-4.6V-Flash",
           "context": "128K",
           "maxOutput": "~4K",
@@ -179,6 +196,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "llama3.1-8b",
           "name": "llama3.1-8b",
           "context": "128K (8K on free)",
           "maxOutput": "8K",
@@ -186,6 +204,7 @@
           "rateLimit": "30 RPM, 14,400 RPD, 1M TPD"
         },
         {
+          "id": "gpt-oss-120b",
           "name": "gpt-oss-120b",
           "context": "128K (8K on free)",
           "maxOutput": "8K",
@@ -193,6 +212,7 @@
           "rateLimit": "30 RPM, 14,400 RPD, 1M TPD"
         },
         {
+          "id": "qwen-3-235b-a22b-instruct-2507",
           "name": "qwen-3-235b-a22b-instruct-2507",
           "context": "131K (8K on free)",
           "maxOutput": "8K",
@@ -200,6 +220,7 @@
           "rateLimit": "30 RPM, 14,400 RPD, 1M TPD"
         },
         {
+          "id": "zai-glm-4.7",
           "name": "zai-glm-4.7",
           "context": "128K (8K on free)",
           "maxOutput": "8K",
@@ -219,6 +240,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
           "name": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
           "context": "131K",
           "maxOutput": "Shared w/ context",
@@ -226,6 +248,7 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
+          "id": "@cf/meta/llama-3.1-8b-instruct-fp8-fast",
           "name": "@cf/meta/llama-3.1-8b-instruct-fp8-fast",
           "context": "131K",
           "maxOutput": "Shared w/ context",
@@ -233,6 +256,7 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
+          "id": "@cf/meta/llama-3.2-11b-vision-instruct",
           "name": "@cf/meta/llama-3.2-11b-vision-instruct",
           "context": "131K",
           "maxOutput": "Shared w/ context",
@@ -240,6 +264,7 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
+          "id": "@cf/meta/llama-4-scout-17b-16e-instruct",
           "name": "@cf/meta/llama-4-scout-17b-16e-instruct",
           "context": "Up to 10M",
           "maxOutput": "Shared w/ context",
@@ -247,6 +272,7 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
+          "id": "@cf/mistralai/mistral-small-3.1-24b-instruct",
           "name": "@cf/mistralai/mistral-small-3.1-24b-instruct",
           "context": "128K",
           "maxOutput": "Shared w/ context",
@@ -254,6 +280,7 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
+          "id": "@cf/google/gemma-4-26b-a4b-it",
           "name": "@cf/google/gemma-4-26b-a4b-it",
           "context": "256K",
           "maxOutput": "Shared w/ context",
@@ -261,6 +288,7 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
+          "id": "@cf/qwen/qwq-32b",
           "name": "@cf/qwen/qwq-32b",
           "context": "32K",
           "maxOutput": "Shared w/ context",
@@ -268,6 +296,7 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
+          "id": "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
           "name": "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
           "context": "32K",
           "maxOutput": "Shared w/ context",
@@ -275,6 +304,7 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
+          "id": null,
           "name": "+ 42 more models",
           "context": "Varies",
           "maxOutput": "Varies",
@@ -294,6 +324,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "gpt-4.1",
           "name": "gpt-4.1",
           "context": "1M",
           "maxOutput": "32K",
@@ -301,6 +332,7 @@
           "rateLimit": "10 RPM, 50 RPD"
         },
         {
+          "id": "gpt-4.1-mini",
           "name": "gpt-4.1-mini",
           "context": "1M",
           "maxOutput": "32K",
@@ -308,6 +340,7 @@
           "rateLimit": "15 RPM, 150 RPD"
         },
         {
+          "id": "gpt-4o",
           "name": "gpt-4o",
           "context": "128K",
           "maxOutput": "16K",
@@ -315,6 +348,7 @@
           "rateLimit": "10 RPM, 50 RPD"
         },
         {
+          "id": "o3-mini",
           "name": "o3-mini",
           "context": "200K",
           "maxOutput": "100K",
@@ -322,6 +356,7 @@
           "rateLimit": "10 RPM, 50 RPD"
         },
         {
+          "id": "o4-mini",
           "name": "o4-mini",
           "context": "200K",
           "maxOutput": "100K",
@@ -329,6 +364,7 @@
           "rateLimit": "10 RPM, 50 RPD"
         },
         {
+          "id": "Llama-4-Scout-17B-16E-Instruct",
           "name": "Llama-4-Scout-17B-16E",
           "context": "512K",
           "maxOutput": "~4K",
@@ -336,6 +372,7 @@
           "rateLimit": "15 RPM, 150 RPD"
         },
         {
+          "id": "Llama-4-Maverick-17B-128E-Instruct",
           "name": "Llama-4-Maverick-17B-128E",
           "context": "256K",
           "maxOutput": "~4K",
@@ -343,6 +380,7 @@
           "rateLimit": "10 RPM, 50 RPD"
         },
         {
+          "id": "Meta-Llama-3.3-70B-Instruct",
           "name": "Meta-Llama-3.3-70B",
           "context": "131K",
           "maxOutput": "~4K",
@@ -350,6 +388,7 @@
           "rateLimit": "15 RPM, 150 RPD"
         },
         {
+          "id": "DeepSeek-R1",
           "name": "DeepSeek-R1",
           "context": "64K",
           "maxOutput": "8K",
@@ -357,6 +396,7 @@
           "rateLimit": "15 RPM, 150 RPD"
         },
         {
+          "id": "Mistral-Small-3.1-24B-Instruct",
           "name": "Mistral-Small-3.1",
           "context": "128K",
           "maxOutput": "~4K",
@@ -364,6 +404,7 @@
           "rateLimit": "15 RPM, 150 RPD"
         },
         {
+          "id": null,
           "name": "+ 35 more models",
           "context": "Varies",
           "maxOutput": "Varies",
@@ -383,6 +424,7 @@
       "footnoteRef": 2,
       "models": [
         {
+          "id": "llama-3.3-70b-versatile",
           "name": "llama-3.3-70b-versatile",
           "context": "131K",
           "maxOutput": "32K",
@@ -390,6 +432,7 @@
           "rateLimit": "30 RPM, 14,400 RPD"
         },
         {
+          "id": "llama-3.1-8b-instant",
           "name": "llama-3.1-8b-instant",
           "context": "131K",
           "maxOutput": "131K",
@@ -397,6 +440,7 @@
           "rateLimit": "30 RPM, 14,400 RPD"
         },
         {
+          "id": "llama-4-scout-17b-16e-instruct",
           "name": "llama-4-scout-17b-16e-instruct",
           "context": "131K",
           "maxOutput": "8K",
@@ -404,6 +448,7 @@
           "rateLimit": "30 RPM, 14,400 RPD"
         },
         {
+          "id": "llama-4-maverick-17b-128e-instruct",
           "name": "llama-4-maverick-17b-128e-instruct",
           "context": "131K",
           "maxOutput": "8K",
@@ -411,6 +456,7 @@
           "rateLimit": "15 RPM, 500 RPD"
         },
         {
+          "id": "qwen3-32b",
           "name": "qwen3-32b",
           "context": "131K",
           "maxOutput": "131K",
@@ -418,6 +464,7 @@
           "rateLimit": "30 RPM, 14,400 RPD"
         },
         {
+          "id": "gpt-oss-120b",
           "name": "gpt-oss-120b",
           "context": "131K",
           "maxOutput": "32K",
@@ -425,6 +472,7 @@
           "rateLimit": "30 RPM, 14,400 RPD"
         },
         {
+          "id": "kimi-k2-instruct",
           "name": "kimi-k2-instruct",
           "context": "262K",
           "maxOutput": "262K",
@@ -432,6 +480,7 @@
           "rateLimit": "30 RPM, 14,400 RPD"
         },
         {
+          "id": "deepseek-r1-distill-70b",
           "name": "deepseek-r1-distill-70b",
           "context": "131K",
           "maxOutput": "8K",
@@ -439,6 +488,7 @@
           "rateLimit": "30 RPM, 14,400 RPD"
         },
         {
+          "id": "whisper-large-v3",
           "name": "whisper-large-v3",
           "context": "—",
           "maxOutput": "—",
@@ -446,6 +496,7 @@
           "rateLimit": "20 RPM, 2,000 RPD"
         },
         {
+          "id": "whisper-large-v3-turbo",
           "name": "whisper-large-v3-turbo",
           "context": "—",
           "maxOutput": "—",
@@ -465,6 +516,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
           "name": "Meta-Llama-3.1-8B-Instruct",
           "context": "128K",
           "maxOutput": "~4K",
@@ -472,6 +524,7 @@
           "rateLimit": "~1,000 RPD"
         },
         {
+          "id": "mistralai/Mistral-7B-Instruct-v0.3",
           "name": "Mistral-7B-Instruct-v0.3",
           "context": "32K",
           "maxOutput": "~4K",
@@ -479,6 +532,7 @@
           "rateLimit": "~1,000 RPD"
         },
         {
+          "id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
           "name": "Mixtral-8x7B-Instruct-v0.1",
           "context": "32K",
           "maxOutput": "~4K",
@@ -486,6 +540,7 @@
           "rateLimit": "~1,000 RPD"
         },
         {
+          "id": "microsoft/Phi-3.5-mini-instruct",
           "name": "Phi-3.5-mini-instruct",
           "context": "128K",
           "maxOutput": "~4K",
@@ -493,6 +548,7 @@
           "rateLimit": "~1,000 RPD"
         },
         {
+          "id": "Qwen/Qwen2.5-7B-Instruct",
           "name": "Qwen2.5-7B-Instruct",
           "context": "131K",
           "maxOutput": "~4K",
@@ -500,6 +556,7 @@
           "rateLimit": "~1,000 RPD"
         },
         {
+          "id": null,
           "name": "+ thousands of community models",
           "context": "Varies",
           "maxOutput": "Varies",
@@ -519,6 +576,7 @@
       "footnoteRef": 5,
       "models": [
         {
+          "id": "bytedance-seed/dola-seed-2.0-pro:free",
           "name": "bytedance-seed/dola-seed-2.0-pro:free",
           "context": "—",
           "maxOutput": "—",
@@ -526,6 +584,7 @@
           "rateLimit": "~200 req/hr"
         },
         {
+          "id": "x-ai/grok-code-fast-1:optimized:free",
           "name": "x-ai/grok-code-fast-1:optimized:free",
           "context": "—",
           "maxOutput": "—",
@@ -533,6 +592,7 @@
           "rateLimit": "~200 req/hr"
         },
         {
+          "id": "nvidia/nemotron-3-super-120b-a12b:free",
           "name": "nvidia/nemotron-3-super-120b-a12b:free",
           "context": "262K",
           "maxOutput": "32K",
@@ -540,6 +600,7 @@
           "rateLimit": "~200 req/hr"
         },
         {
+          "id": "arcee-ai/trinity-large-thinking:free",
           "name": "arcee-ai/trinity-large-thinking:free",
           "context": "—",
           "maxOutput": "—",
@@ -547,6 +608,7 @@
           "rateLimit": "~200 req/hr"
         },
         {
+          "id": "openrouter/free",
           "name": "openrouter/free",
           "context": "Varies",
           "maxOutput": "Varies",
@@ -566,6 +628,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "deepseek-r1-0528",
           "name": "deepseek-r1-0528",
           "context": "—",
           "maxOutput": "—",
@@ -573,6 +636,7 @@
           "rateLimit": "30 RPM (120 with token)"
         },
         {
+          "id": "deepseek-v3-0324",
           "name": "deepseek-v3-0324",
           "context": "—",
           "maxOutput": "—",
@@ -580,6 +644,7 @@
           "rateLimit": "30 RPM (120 with token)"
         },
         {
+          "id": "gemini-2.5-flash-lite",
           "name": "gemini-2.5-flash-lite",
           "context": "—",
           "maxOutput": "—",
@@ -587,6 +652,7 @@
           "rateLimit": "30 RPM (120 with token)"
         },
         {
+          "id": "gpt-4o-mini",
           "name": "gpt-4o-mini",
           "context": "—",
           "maxOutput": "—",
@@ -594,6 +660,7 @@
           "rateLimit": "30 RPM (120 with token)"
         },
         {
+          "id": "mistral-small-3.1-24b",
           "name": "mistral-small-3.1-24b",
           "context": "32K",
           "maxOutput": "—",
@@ -601,6 +668,7 @@
           "rateLimit": "30 RPM (120 with token)"
         },
         {
+          "id": "qwen2.5-coder-32b",
           "name": "qwen2.5-coder-32b",
           "context": "—",
           "maxOutput": "—",
@@ -608,6 +676,7 @@
           "rateLimit": "30 RPM (120 with token)"
         },
         {
+          "id": null,
           "name": "+ ~24 more models",
           "context": "Varies",
           "maxOutput": "Varies",
@@ -627,6 +696,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "deepseek-ai/deepseek-r1",
           "name": "deepseek-ai/deepseek-r1",
           "context": "128K",
           "maxOutput": "~163K",
@@ -634,6 +704,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
           "name": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
           "context": "128K",
           "maxOutput": "4K",
@@ -641,6 +712,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": "nvidia/nemotron-3-super-120b-a12b",
           "name": "nvidia/nemotron-3-super-120b-a12b",
           "context": "262K",
           "maxOutput": "262K",
@@ -648,6 +720,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": "nvidia/nemotron-3-nano-30b-a3b",
           "name": "nvidia/nemotron-3-nano-30b-a3b",
           "context": "128K",
           "maxOutput": "32K",
@@ -655,6 +728,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": "meta/llama-3.1-405b-instruct",
           "name": "meta/llama-3.1-405b-instruct",
           "context": "128K",
           "maxOutput": "4K",
@@ -662,6 +736,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": "qwen/qwen2.5-72b-instruct",
           "name": "qwen/qwen2.5-72b-instruct",
           "context": "128K",
           "maxOutput": "8K",
@@ -669,6 +744,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": "google/gemma-4-31b",
           "name": "google/gemma-4-31b",
           "context": "128K",
           "maxOutput": "8K",
@@ -676,6 +752,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": "mistralai/mistral-large-2-instruct",
           "name": "mistralai/mistral-large-2-instruct",
           "context": "128K",
           "maxOutput": "4K",
@@ -683,6 +760,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": "nvidia/nemotron-nano-2-vl",
           "name": "nvidia/nemotron-nano-2-vl",
           "context": "128K",
           "maxOutput": "8K",
@@ -690,6 +768,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": "minimax/minimax-m2.7",
           "name": "minimax/minimax-m2.7",
           "context": "128K",
           "maxOutput": "8K",
@@ -697,6 +776,7 @@
           "rateLimit": "~40 RPM"
         },
         {
+          "id": null,
           "name": "+ 90 more models",
           "context": "Varies",
           "maxOutput": "Varies",
@@ -716,6 +796,7 @@
       "footnoteRef": 3,
       "models": [
         {
+          "id": "llama3.1:cloud",
           "name": "llama3.1:cloud",
           "context": "128K",
           "maxOutput": "Model-dependent",
@@ -723,6 +804,7 @@
           "rateLimit": "Session/weekly limits (unpublished)"
         },
         {
+          "id": "deepseek-r1:cloud",
           "name": "deepseek-r1:cloud",
           "context": "128K",
           "maxOutput": "Model-dependent",
@@ -730,6 +812,7 @@
           "rateLimit": "Session/weekly limits (unpublished)"
         },
         {
+          "id": "qwen2.5:cloud",
           "name": "qwen2.5:cloud",
           "context": "128K",
           "maxOutput": "Model-dependent",
@@ -737,6 +820,7 @@
           "rateLimit": "Session/weekly limits (unpublished)"
         },
         {
+          "id": "gemma2:cloud",
           "name": "gemma2:cloud",
           "context": "8K",
           "maxOutput": "Model-dependent",
@@ -744,6 +828,7 @@
           "rateLimit": "Session/weekly limits (unpublished)"
         },
         {
+          "id": "mistral:cloud",
           "name": "mistral:cloud",
           "context": "32K",
           "maxOutput": "Model-dependent",
@@ -751,6 +836,7 @@
           "rateLimit": "Session/weekly limits (unpublished)"
         },
         {
+          "id": null,
           "name": "+ 400 more models",
           "context": "Varies",
           "maxOutput": "Varies",
@@ -770,6 +856,7 @@
       "footnoteRef": 4,
       "models": [
         {
+          "id": "deepseek/deepseek-r1-0528:free",
           "name": "deepseek/deepseek-r1-0528:free",
           "context": "163K",
           "maxOutput": "~163K",
@@ -777,6 +864,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "deepseek/deepseek-chat-v3-0324:free",
           "name": "deepseek/deepseek-chat-v3-0324:free",
           "context": "163K",
           "maxOutput": "163K",
@@ -784,6 +872,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "qwen/qwen3.6-plus:free",
           "name": "qwen/qwen3.6-plus:free",
           "context": "1M",
           "maxOutput": "65K",
@@ -791,6 +880,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "qwen/qwen3-coder-480b-a35b:free",
           "name": "qwen/qwen3-coder-480b-a35b:free",
           "context": "262K",
           "maxOutput": "~32K",
@@ -798,6 +888,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "meta-llama/llama-4-scout:free",
           "name": "meta-llama/llama-4-scout:free",
           "context": "10M",
           "maxOutput": "16K",
@@ -805,6 +896,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "meta-llama/llama-4-maverick:free",
           "name": "meta-llama/llama-4-maverick:free",
           "context": "1M",
           "maxOutput": "16K",
@@ -812,6 +904,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "meta-llama/llama-3.3-70b-instruct:free",
           "name": "meta-llama/llama-3.3-70b-instruct:free",
           "context": "65K",
           "maxOutput": "~16K",
@@ -819,6 +912,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "google/gemma-4-31b-it:free",
           "name": "google/gemma-4-31b-it:free",
           "context": "256K",
           "maxOutput": "~8K",
@@ -826,6 +920,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "nvidia/nemotron-3-super-120b-a12b:free",
           "name": "nvidia/nemotron-3-super-120b-a12b:free",
           "context": "1M",
           "maxOutput": "~32K",
@@ -833,6 +928,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "openai/gpt-oss-120b:free",
           "name": "openai/gpt-oss-120b:free",
           "context": "131K",
           "maxOutput": "131K",
@@ -840,6 +936,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "minimax/minimax-m2.5:free",
           "name": "minimax/minimax-m2.5:free",
           "context": "196K",
           "maxOutput": "8K",
@@ -847,6 +944,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": "mistralai/devstral-2512:free",
           "name": "mistralai/devstral-2512:free",
           "context": "256K",
           "maxOutput": "~32K",
@@ -854,6 +952,7 @@
           "rateLimit": "20 RPM, 200 RPD"
         },
         {
+          "id": null,
           "name": "+ ~23 more free models",
           "context": "Varies",
           "maxOutput": "Varies",
@@ -873,6 +972,7 @@
       "footnoteRef": null,
       "models": [
         {
+          "id": "Qwen/Qwen3-8B",
           "name": "Qwen/Qwen3-8B",
           "context": "131K",
           "maxOutput": "131K",
@@ -880,6 +980,7 @@
           "rateLimit": "1,000 RPM, 50K TPM"
         },
         {
+          "id": "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
           "name": "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
           "context": "~33K",
           "maxOutput": "16K",
@@ -887,6 +988,7 @@
           "rateLimit": "1,000 RPM, 50K TPM"
         },
         {
+          "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
           "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
           "context": "131K",
           "maxOutput": "Configurable",
@@ -894,6 +996,7 @@
           "rateLimit": "1,000 RPM, 50K TPM"
         },
         {
+          "id": "THUDM/glm-4-9b-chat",
           "name": "THUDM/glm-4-9b-chat",
           "context": "32K",
           "maxOutput": "32K",
@@ -901,6 +1004,7 @@
           "rateLimit": "1,000 RPM, 50K TPM"
         },
         {
+          "id": "THUDM/GLM-4.1V-9B-Thinking",
           "name": "THUDM/GLM-4.1V-9B-Thinking",
           "context": "66K",
           "maxOutput": "66K",
@@ -908,6 +1012,7 @@
           "rateLimit": "1,000 RPM, 50K TPM"
         },
         {
+          "id": "deepseek-ai/DeepSeek-OCR",
           "name": "deepseek-ai/DeepSeek-OCR",
           "context": "—",
           "maxOutput": "8K",
@@ -915,6 +1020,7 @@
           "rateLimit": "1,000 RPM, 50K TPM"
         },
         {
+          "id": null,
           "name": "+ embedding/speech models",
           "context": "Varies",
           "maxOutput": "Varies",
@@ -947,10 +1053,25 @@
     }
   ],
   "glossary": [
-    { "abbreviation": "RPM", "meaning": "Requests per minute" },
-    { "abbreviation": "RPD", "meaning": "Requests per day" },
-    { "abbreviation": "TPM", "meaning": "Tokens per minute" },
-    { "abbreviation": "TPD", "meaning": "Tokens per day" },
-    { "abbreviation": "RPS", "meaning": "Requests per second" }
+    {
+      "abbreviation": "RPM",
+      "meaning": "Requests per minute"
+    },
+    {
+      "abbreviation": "RPD",
+      "meaning": "Requests per day"
+    },
+    {
+      "abbreviation": "TPM",
+      "meaning": "Tokens per minute"
+    },
+    {
+      "abbreviation": "TPD",
+      "meaning": "Tokens per day"
+    },
+    {
+      "abbreviation": "RPS",
+      "meaning": "Requests per second"
+    }
   ]
 }


### PR DESCRIPTION
Adds an `id` field to every model entry — the actual string to send in API requests. Display names stay in `name`. Catch-all rows (e.g. '+ 42 more models') have `id: null`.