### PR TITLE
fix: align readme layout with sindresorhus/awesome guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-<div align="center">
-	<br>
-	<img src="media/awesome-free-llm-apis.png" width="500" alt="Awesome Free LLM APIs">
-	<br>
-	<br>
+<h1 align="center">
+	<a href="https://github.com/mnfst/awesome-free-llm-apis">
+		<img src="media/awesome-free-llm-apis.png" width="500" alt="Awesome Free LLM APIs">
+	</a>
+</h1>
+
+<p align="center">
 	<a href="https://awesome.re">
 		<img src="https://awesome.re/badge-flat2.svg" alt="Awesome">
 	</a>
-	<br>
-	<br>
-	<p>LLM APIs with permanent free tiers for text inference.</p>
-	<br>
-	<br>
-</div>
+</p>
+
+<p align="center">LLM APIs with permanent free tiers for text inference.</p>
+
+<p align="center"><sub>All endpoints are OpenAI SDK-compatible unless noted. Each link points to the provider's API key page.</sub></p>
 
 ## Contents
 
 - [Provider APIs](#provider-apis)
 - [Inference providers](#inference-providers)
 - [Glossary](#glossary)
-- [Notes](#notes)
 
 ## Provider APIs
 
@@ -282,10 +282,6 @@ Base URL: `https://api.siliconflow.cn/v1`
 | deepseek-ai/DeepSeek-OCR                | —       | 8K           | Vision (OCR)       | 1,000 RPM, 50K TPM |
 | + embedding/speech models               | Varies  | Varies       | Embeddings, Speech | 1,000 RPM, 50K TPM |
 
-## Contributing
-
-Know a free tier that's missing? [Open a PR](contributing.md). Include the provider, endpoint, rate limits (link to their docs), and a few notable models. Trial credits and time-limited promos don't count.
-
 ## Glossary
 
 | Abbreviation | Meaning             |
@@ -296,10 +292,9 @@ Know a free tier that's missing? [Open a PR](contributing.md). Include the provi
 | **TPD**      | Tokens per day      |
 | **RPS**      | Requests per second |
 
-## Notes
+## Contributing
 
-- All endpoints are OpenAI SDK-compatible unless noted.
-- Each link points to the provider's API key page.
+Know a free tier that's missing? [Open a PR](contributing.md). Include the provider, endpoint, rate limits (link to their docs), and a few notable models. Trial credits and time-limited promos don't count.
 
 [^1]: Free tier not available in the EU, UK, or Switzerland ([available regions](https://ai.google.dev/gemini-api/docs/available-regions)).
 [^2]: Groq rate limits vary by model. Llama 4 Maverick is limited to 500 RPD. Most other models get 14,400 RPD ([rate limits](https://console.groq.com/docs/rate-limits)).

--- a/scripts/generate-readme.js
+++ b/scripts/generate-readme.js
@@ -7,20 +7,21 @@ const path = require('path');
 const ROOT = path.join(__dirname, '..');
 const data = JSON.parse(fs.readFileSync(path.join(ROOT, 'data.json'), 'utf8'));
 
-const HEADER = `<div align="center">
-\t<br>
-\t<img src="media/awesome-free-llm-apis.png" width="500" alt="Awesome Free LLM APIs">
-\t<br>
-\t<br>
+const HEADER = `<h1 align="center">
+\t<a href="https://github.com/mnfst/awesome-free-llm-apis">
+\t\t<img src="media/awesome-free-llm-apis.png" width="500" alt="Awesome Free LLM APIs">
+\t</a>
+</h1>
+
+<p align="center">
 \t<a href="https://awesome.re">
 \t\t<img src="https://awesome.re/badge-flat2.svg" alt="Awesome">
 \t</a>
-\t<br>
-\t<br>
-\t<p>LLM APIs with permanent free tiers for text inference.</p>
-\t<br>
-\t<br>
-</div>`;
+</p>
+
+<p align="center">LLM APIs with permanent free tiers for text inference.</p>
+
+<p align="center"><sub>All endpoints are OpenAI SDK-compatible unless noted. Each link points to the provider's API key page.</sub></p>`;
 
 function alignTable(header, rows) {
 	const widths = header.map((cell, i) => {
@@ -81,7 +82,6 @@ const parts = [
 	'- [Provider APIs](#provider-apis)',
 	'- [Inference providers](#inference-providers)',
 	'- [Glossary](#glossary)',
-	'- [Notes](#notes)',
 	'',
 	'## Provider APIs',
 	'',
@@ -95,18 +95,13 @@ const parts = [
 	'',
 	inferenceProviders.map(buildProviderSection).join('\n\n'),
 	'',
-	'## Contributing',
-	'',
-	'Know a free tier that\'s missing? [Open a PR](contributing.md). Include the provider, endpoint, rate limits (link to their docs), and a few notable models. Trial credits and time-limited promos don\'t count.',
-	'',
 	'## Glossary',
 	'',
 	glossaryTable,
 	'',
-	'## Notes',
+	'## Contributing',
 	'',
-	'- All endpoints are OpenAI SDK-compatible unless noted.',
-	'- Each link points to the provider\'s API key page.',
+	'Know a free tier that\'s missing? [Open a PR](contributing.md). Include the provider, endpoint, rate limits (link to their docs), and a few notable models. Trial credits and time-limited promos don\'t count.',
 	'',
 	footnoteLines,
 	'',


### PR DESCRIPTION
## Summary

Follow-up to #40. After walking through the full sindresorhus/awesome [pull request template](https://github.com/sindresorhus/awesome/blob/main/pull_request_template.md) checklist, four structural items weren't quite right. This fixes them.

## What the template requires, and how it's addressed

### 1. Proper `<h1>` heading

> The heading title of your list should be in title case format: `# Awesome Name of List`.
>
> You can put the header image in a `#` (Markdown header) or `<h1>`.

The previous header used a `<div align="center">` wrapping the logo, so the list had no top-level heading element at all. The new header is an `<h1 align="center">` that contains the logo (same pattern as [awesome-mac](https://github.com/jaywcjlove/awesome-mac)).

### 2. Logo image linked to a relevant URL

> The image should link to the project website or any relevant website.

The logo is now wrapped in `<a href="https://github.com/mnfst/awesome-free-llm-apis">`. The awesome.re badge below was already linked; only the main logo needed it.

### 3. Contributing section position

> It can optionally be linked from the readme in a dedicated section titled `Contributing`, positioned at the top or bottom of the main content. The section should not appear in the Table of Contents.

The `## Contributing` section used to sit between Inference providers and Glossary. It now lives below Glossary, at the bottom of the curated content, right before the auto-rendered footnotes. It was already absent from the TOC.

### 4. Footnote content not in TOC

> All non-important but necessary content (like extra copyright notices, hyperlinks to sources, pointers to expansive content, etc) should be grouped in a `Footnotes` section at the bottom of the readme. The section should not be present in the Table of Contents.

The old `## Notes` section held two global clarifications plus all the `[^N]` definitions, and was listed in the TOC. The two clarifications now appear as a small `<sub>` line under the tagline in the header. The `[^N]` definitions stay where they were and GitHub still renders them as a "Footnotes" section at the bottom — with no TOC entry, as required.

## Verification

```bash
node scripts/generate-readme.js
npx awesome-lint
# 0 errors, 1 unrelated warning (literal OpenRouter slug `openai/gpt-oss-120b:free`)
```