### PR TITLE
Add AI Models Catalog — 81 free models with capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ Base URL: `https://api.siliconflow.cn/v1`
 | deepseek-ai/DeepSeek-OCR                | —       | 8K           | Vision (OCR)       | 1,000 RPM, 50K TPM |
 | + embedding/speech models               | Varies  | Varies       | Embeddings, Speech | 1,000 RPM, 50K TPM |
 
+## Model Catalogs
+
+### [AI Models Catalog](https://github.com/i-need-token/ai-models) 🌐
+
+Structured catalog of 4,587+ AI models across 95 providers. Includes 81 free models with tool calling, reasoning, and vision capabilities. Compare pricing, context windows, and capabilities across all providers. Interactive catalog: https://i-need-token.github.io/ai-models/
+
 ## Glossary
 
 | Abbreviation | Meaning             |


### PR DESCRIPTION
## Addition

- **Name:** AI Models Catalog
- **URL:** https://github.com/i-need-token/ai-models

## Description

Structured catalog of 4,587+ AI models across 95 providers. Includes **81 free models** with tool calling, reasoning, and vision capabilities. Compare pricing, context windows, and capabilities across all providers.

## Why this belongs

- **81 free models documented**: Covers all free models from providers listed in this repo (Google Gemini, Cloudflare, Groq, Cerebras, etc.)
- **First-party data**: All data sourced from provider APIs and official documentation
- **Interactive catalog**: https://i-need-token.github.io/ai-models/ — filter by free models, compare capabilities
- **Machine-readable**: Available as JSON, CSV, YAML, npm package
- **Open source**: MIT licensed with automated scraping pipeline

## Checklist

- [x] Entry follows the existing format (provider section with link and description)
- [x] Added to the correct category (Model Catalogs)
- [x] Not a duplicate of existing entries