### PR TITLE
Add A3M Router — cheapest free LLM router ($0.047/1K)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - [Glossary](#glossary)
 
 ## Provider APIs
-
+- [A3M Router](https://github.com/Das-rebel/a3m-router) - #1 LLM routing benchmark & cheapest router with memory. 47+ providers, parallel execution, ensemble voting. ([RouterArena #1](https://github.com/RouteWorks/RouterArena/pull/113))
 APIs run by the companies that train or fine-tune the models themselves.
 
 ### [AI21 Labs](https://studio.ai21.com/account/api-key) 🇮🇱


### PR DESCRIPTION
## A3M Router — #1 LLM Routing Benchmark & Cheapest Router with Memory

Adds A3M Router to the list as the **cheapest LLM router** at $0.047/1K queries.

**Why it fits:**
- Free and open-source (MIT license)
- 47+ free/freemium LLM providers supported
- Cheapest on RouterArena benchmark (#1 score: 76.43)
- Auto-routes to cheapest capable model
- Zero ML dependencies, 19.5KB
- One command: `npx a3m-router route 'your query'`

**Benchmark results:** A3M Router #1 (76.43, $0.047/1K) | Sqwish #2 (75.27, $0.18) | Azure #3 (71.87, $0.22)

GitHub: https://github.com/Das-rebel/a3m-router
npm: https://www.npmjs.com/package/adaptive-memory-multi-model-router