### PR TITLE
feat: refresh free-tier providers (2026-06-15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,42 +24,17 @@
 
 APIs run by the companies that train or fine-tune the models themselves.
 
-### [AI21 Labs](https://studio.ai21.com/account/api-key) 🇮🇱
-
-$10 trial credits at signup, no credit card. Credits expire in 3 months. Covers Jamba Large and Jamba Mini.
-
-Base URL: `https://api.ai21.com/studio/v1`
-
-| Model Name      | Context | Max Output | Modality | Rate Limit      |
-| --------------- | ------- | ---------- | -------- | --------------- |
-| Jamba Large 1.7 | 256K    | 4K         | Text     | 200 RPM, 10 RPS |
-| Jamba Mini 2    | 256K    | 4K         | Text     | 200 RPM, 10 RPS |
-
 ### [Aion Labs](https://www.aionlabs.ai) 🇮🇱
 
-Free daily token allowance, no credit card required. Specialized for roleplay and storytelling.
+Permanent free tier, no credit card required. 15 RPM, 20K tokens/day. Specialized for roleplay and storytelling.
 
 Base URL: `https://api.aionlabs.ai/v1`
 
-| Model Name    | Context | Max Output | Modality        | Rate Limit            |
-| ------------- | ------- | ---------- | --------------- | --------------------- |
-| aion-2.0      | 131K    | ~32K       | Text (roleplay) | Daily token allowance |
-| aion-1.0      | 131K    | ~32K       | Text            | Daily token allowance |
-| aion-1.0-mini | 131K    | ~32K       | Text            | Daily token allowance |
-
-### [Alibaba Cloud Model Studio](https://bailian.console.alibabacloud.com/?apiKey=1) 🇨🇳
-
-1M free tokens per Qwen model on signup, expires in 90 days (International / Singapore region). No credit card required. [^8]
-
-Base URL: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
-
-| Model Name       | Context | Max Output | Modality         | Rate Limit       |
-| ---------------- | ------- | ---------- | ---------------- | ---------------- |
-| Qwen3-Max        | 128K    | 32K        | Text             | Tiered by region |
-| Qwen3-Plus       | 1M      | 32K        | Text             | Tiered by region |
-| Qwen3-VL-Plus    | 128K    | 8K         | Text + Vision    | Tiered by region |
-| Qwen3-Coder-Plus | 256K    | 8K         | Text (code)      | Tiered by region |
-| QwQ-Plus         | 131K    | 32K        | Text (reasoning) | Tiered by region |
+| Model Name       | Context | Max Output | Modality        | Rate Limit      |
+| ---------------- | ------- | ---------- | --------------- | --------------- |
+| Aion 2.5         | 128K    | 32K        | Text (roleplay) | 15 RPM, 20K TPD |
+| Aion 2.0         | 128K    | 32K        | Text (roleplay) | 15 RPM, 20K TPD |
+| Aion-RP 1.0 (8B) | 32K     | ~8K        | Text (roleplay) | 15 RPM, 20K TPD |
 
 ### [Cohere](https://dashboard.cohere.com/api-keys) 🇨🇦
 
@@ -67,25 +42,13 @@ Free "Trial" API key, no credit card. 1,000 API calls/month. Non-commercial use 
 
 Base URL: `https://api.cohere.com/v2`
 
-| Model Name       | Context | Max Output | Modality                  | Rate Limit       |
-| ---------------- | ------- | ---------- | ------------------------- | ---------------- |
-| Command A (111B) | 256K    | 4K         | Text                      | 20 RPM           |
-| Command R+       | 128K    | 4K         | Text                      | 20 RPM           |
-| Command R        | 128K    | 4K         | Text                      | 20 RPM           |
-| Command R7B      | 128K    | 4K         | Text                      | 20 RPM           |
-| Embed 4          | —       | —          | Embeddings (Text + Image) | 2,000 inputs/min |
-| Rerank 3.5       | —       | —          | Reranking                 | 10 RPM           |
-
-### [DeepSeek](https://platform.deepseek.com/api_keys) 🇨🇳
-
-5M free tokens on signup, no credit card. Credits expire 30 days after signup; pay-as-you-go after. Prompts may be used for training unless opted out. [^9]
-
-Base URL: `https://api.deepseek.com/v1`
-
-| Model Name             | Context | Max Output | Modality         | Rate Limit |
-| ---------------------- | ------- | ---------- | ---------------- | ---------- |
-| deepseek-chat (V3.2)   | 128K    | 8K         | Text             | Dynamic    |
-| deepseek-reasoner (R1) | 128K    | 8K         | Text (reasoning) | Dynamic    |
+| Model Name        | Context | Max Output | Modality | Rate Limit |
+| ----------------- | ------- | ---------- | -------- | ---------- |
+| Command A+ (218B) | 128K    | 4K         | Text     | 20 RPM     |
+| Command A (111B)  | 256K    | 4K         | Text     | 20 RPM     |
+| Command R+        | 128K    | 4K         | Text     | 20 RPM     |
+| Command R         | 128K    | 4K         | Text     | 20 RPM     |
+| Command R7B       | 128K    | 4K         | Text     | 20 RPM     |
 
 ### [Google Gemini](https://aistudio.google.com/app/apikey) 🇺🇸
 
@@ -93,12 +56,12 @@ Free tier unavailable in EU/UK/Switzerland. Free-tier prompts may be used by Goo
 
 Base URL: `https://generativelanguage.googleapis.com/v1beta`
 
-| Model Name               | Context | Max Output | Modality                     | Rate Limit        |
-| ------------------------ | ------- | ---------- | ---------------------------- | ----------------- |
-| Gemini 2.5 Pro           | 2M      | 65K        | Text + Image + Audio + Video | 5 RPM, 100 RPD    |
-| Gemini 2.5 Flash         | 1M      | 65K        | Text + Image + Audio + Video | 10 RPM, 250 RPD   |
-| Gemini 2.5 Flash-Lite    | 1M      | 65K        | Text + Image + Audio + Video | 15 RPM, 1,000 RPD |
-| Gemini 3 Flash (Preview) | 1M      | 65K        | Text + Image + Audio + Video | Preview limits    |
+| Model Name            | Context | Max Output | Modality                     | Rate Limit        |
+| --------------------- | ------- | ---------- | ---------------------------- | ----------------- |
+| Gemini 3.5 Flash      | 1M      | 64K        | Text + Image + Audio + Video | 15 RPM, 1,500 RPD |
+| Gemini 3.1 Flash-Lite | 1M      | 65K        | Text + Image + Audio + Video | 30 RPM, 1,500 RPD |
+| Gemini 2.5 Flash      | 1M      | 65K        | Text + Image + Audio + Video | 15 RPM, 1,500 RPD |
+| Gemini 2.5 Pro        | 2M      | 65K        | Text + Image + Audio + Video | 5 RPM, 50 RPD     |
 
 ### [Mistral AI](https://console.mistral.ai/api-keys) 🇫🇷
 
@@ -106,26 +69,14 @@ Free "Experiment" plan, no credit card. ~1B tokens/month. Prompts may be used to
 
 Base URL: `https://api.mistral.ai/v1`
 
-| Model Name         | Context | Max Output | Modality            | Rate Limit       |
-| ------------------ | ------- | ---------- | ------------------- | ---------------- |
-| Mistral Small 4    | 256K    | 256K       | Text + Image + Code | ~1 RPS, 500K TPM |
-| Mistral Medium 3   | 128K    | 128K       | Text                | ~1 RPS, 500K TPM |
-| Mistral Large 3    | 256K    | 256K       | Text                | ~1 RPS, 500K TPM |
-| Mistral Nemo (12B) | 128K    | 128K       | Text                | ~1 RPS, 500K TPM |
-| Codestral          | 256K    | 256K       | Code                | ~1 RPS, 500K TPM |
-| Pixtral Large      | 128K    | 128K       | Text + Image        | ~1 RPS, 500K TPM |
-
-### [xAI](https://console.x.ai) 🇺🇸
-
-$25 sign-up credit, no credit card required. One-time only; additional $150/month available via opt-in data-sharing program (requires prior spend). [^12]
-
-Base URL: `https://api.x.ai/v1`
-
-| Model Name    | Context | Max Output | Modality | Rate Limit   |
-| ------------- | ------- | ---------- | -------- | ------------ |
-| grok-4.3      | 1M      | ~32K       | Text     | Credit-based |
-| grok-4.1-fast | 2M      | ~32K       | Text     | Credit-based |
-| grok-3-mini   | 131K    | 8K         | Text     | Credit-based |
+| Model Name                | Context | Max Output | Modality            | Rate Limit       |
+| ------------------------- | ------- | ---------- | ------------------- | ---------------- |
+| Mistral Medium 3.5 (128B) | 256K    | 256K       | Text + Image + Code | ~1 RPS, 500K TPM |
+| Mistral Small 4           | 256K    | 256K       | Text + Image + Code | ~1 RPS, 500K TPM |
+| Mistral Large 3           | 256K    | 256K       | Text                | ~1 RPS, 500K TPM |
+| Mistral Nemo (12B)        | 128K    | 128K       | Text                | ~1 RPS, 500K TPM |
+| Codestral                 | 256K    | 256K       | Code                | ~1 RPS, 500K TPM |
+| Pixtral Large             | 128K    | 128K       | Text + Image        | ~1 RPS, 500K TPM |
 
 ### [Z AI (Zhipu AI)](https://open.bigmodel.cn/usercenter/apikeys) 🇨🇳
 
@@ -136,7 +87,6 @@ Base URL: `https://open.bigmodel.cn/api/paas/v4`
 | Model Name     | Context | Max Output | Modality     | Rate Limit           |
 | -------------- | ------- | ---------- | ------------ | -------------------- |
 | GLM-4.7-Flash  | 200K    | 128K       | Text         | 1 concurrent request |
-| GLM-4.5-Flash  | 128K    | ~8K        | Text         | 1 concurrent request |
 | GLM-4.6V-Flash | 128K    | ~4K        | Text + Image | 1 concurrent request |
 
 ## Inference providers
@@ -145,18 +95,14 @@ Third-party platforms that host open-weight models from various sources.
 
 ### [Cerebras](https://cloud.cerebras.ai/) 🇺🇸
 
-Free tier, no credit card. Ultra-fast inference (~2,600 tok/s). 1M tokens/day cap. 8K context cap on free tier. llama3.1-8b scheduled for deprecation May 27, 2026.
+Free tier, no credit card. Ultra-fast inference (~2,600 tok/s). 1M tokens/day cap. 8K context cap on free tier.
 
 Base URL: `https://api.cerebras.ai/v1`
 
-| Model Name                     | Context           | Max Output | Modality      | Rate Limit                 |
-| ------------------------------ | ----------------- | ---------- | ------------- | -------------------------- |
-| llama-3.3-70b                  | 128K (8K on free) | 8K         | Text          | 30 RPM, 14,400 RPD, 1M TPD |
-| gpt-oss-120b                   | 128K (8K on free) | 8K         | Text          | 30 RPM, 14,400 RPD, 1M TPD |
-| qwen-3-235b-a22b-instruct-2507 | 131K (8K on free) | 8K         | Text          | 30 RPM, 14,400 RPD, 1M TPD |
-| qwen-3-32b                     | 131K (8K on free) | 8K         | Text          | 30 RPM, 14,400 RPD, 1M TPD |
-| llama-4-scout-17b-16e-instruct | 128K (8K on free) | 8K         | Text + Vision | 30 RPM, 14,400 RPD, 1M TPD |
-| zai-glm-4.7                    | 128K (8K on free) | 8K         | Text          | 10 RPM, 100 RPD, 1M TPD    |
+| Model Name   | Context           | Max Output | Modality | Rate Limit                 |
+| ------------ | ----------------- | ---------- | -------- | -------------------------- |
+| gpt-oss-120b | 128K (8K on free) | 8K         | Text     | 30 RPM, 14,400 RPD, 1M TPD |
+| zai-glm-4.7  | 128K (8K on free) | 8K         | Text     | 10 RPM, 100 RPD, 1M TPD    |
 
 ### [Cloudflare Workers AI](https://dash.cloudflare.com/profile/api-tokens) 🇺🇸
 
@@ -167,12 +113,12 @@ Base URL: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run`
 | Model Name                                     | Context   | Max Output        | Modality                       | Rate Limit               |
 | ---------------------------------------------- | --------- | ----------------- | ------------------------------ | ------------------------ |
 | `@cf/meta/llama-3.3-70b-instruct-fp8-fast`     | 131K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
-| `@cf/meta/llama-3.1-8b-instruct-fp8-fast`      | 131K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
-| `@cf/meta/llama-3.2-11b-vision-instruct`       | 131K      | Shared w/ context | Text + Vision                  | 10K neurons/day (shared) |
 | `@cf/meta/llama-4-scout-17b-16e-instruct`      | Up to 10M | Shared w/ context | Multimodal                     | 10K neurons/day (shared) |
-| `@cf/mistralai/mistral-small-3.1-24b-instruct` | 128K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
+| `@cf/openai/gpt-oss-120b`                      | 128K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
+| `@cf/moonshotai/kimi-k2.7-code`                | 262K      | Shared w/ context | Text (code)                    | 10K neurons/day (shared) |
 | `@cf/google/gemma-4-26b-a4b-it`                | 256K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
-| `@cf/moonshotai/kimi-k2.5`                     | 256K      | Shared w/ context | Text + Vision                  | 10K neurons/day (shared) |
+| `@cf/zhipuai/glm-4.7-flash`                    | 131K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
+| `@cf/mistralai/mistral-small-3.1-24b-instruct` | 128K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
 | `@cf/deepseek-ai/deepseek-r1-distill-qwen-32b` | 32K       | Shared w/ context | Text (reasoning)               | 10K neurons/day (shared) |
 | + 42 more models                               | Varies    | Varies            | Text, Image, Audio, Embeddings | 10K neurons/day (shared) |
 
@@ -202,18 +148,13 @@ Free tier, no credit card. Ultra-fast LPU inference. [^2]
 
 Base URL: `https://api.groq.com/openai/v1`
 
-| Model Name                         | Context | Max Output | Modality      | Rate Limit         |
-| ---------------------------------- | ------- | ---------- | ------------- | ------------------ |
-| llama-3.3-70b-versatile            | 131K    | 32K        | Text          | 30 RPM, 14,400 RPD |
-| llama-3.1-8b-instant               | 131K    | 131K       | Text          | 30 RPM, 14,400 RPD |
-| llama-4-scout-17b-16e-instruct     | 131K    | 8K         | Text + Vision | 30 RPM, 14,400 RPD |
-| llama-4-maverick-17b-128e-instruct | 131K    | 8K         | Text + Vision | 15 RPM, 500 RPD    |
-| qwen3-32b                          | 131K    | 131K       | Text          | 30 RPM, 14,400 RPD |
-| gpt-oss-120b                       | 131K    | 32K        | Text          | 30 RPM, 14,400 RPD |
-| kimi-k2-instruct                   | 262K    | 262K       | Text          | 30 RPM, 14,400 RPD |
-| deepseek-r1-distill-70b            | 131K    | 8K         | Text          | 30 RPM, 14,400 RPD |
-| whisper-large-v3                   | —       | —          | Audio → Text  | 20 RPM, 2,000 RPD  |
-| whisper-large-v3-turbo             | —       | —          | Audio → Text  | 20 RPM, 2,000 RPD  |
+| Model Name                     | Context | Max Output | Modality      | Rate Limit        |
+| ------------------------------ | ------- | ---------- | ------------- | ----------------- |
+| llama-3.3-70b-versatile        | 131K    | 32K        | Text          | 30 RPM, 1,000 RPD |
+| llama-3.1-8b-instant           | 131K    | 131K       | Text          | 30 RPM, 1,000 RPD |
+| llama-4-scout-17b-16e-instruct | 131K    | 8K         | Text + Vision | 30 RPM, 1,000 RPD |
+| qwen3-32b                      | 131K    | 131K       | Text          | 30 RPM, 1,000 RPD |
+| gpt-oss-120b                   | 131K    | 32K        | Text          | 30 RPM, 1,000 RPD |
 
 ### [Hugging Face](https://huggingface.co/settings/tokens) 🇺🇸
 
@@ -267,41 +208,11 @@ Free API-Inference for registered users. Requires Alibaba Cloud account binding 
 
 Base URL: `https://api-inference.modelscope.cn/v1`
 
-| Model Name                     | Context | Max Output | Modality         | Rate Limit                                 |
-| ------------------------------ | ------- | ---------- | ---------------- | ------------------------------------------ |
-| `Qwen/Qwen3.5-35B-A3B`         | —       | —          | Text + Vision    | 2,000 RPD total; <=500 RPD/model (dynamic) |
-| `Qwen/Qwen3.5-27B`             | —       | —          | Text             | 2,000 RPD total; <=500 RPD/model (dynamic) |
-| `Qwen/Qwen-Image`              | —       | —          | Image Generation | 2,000 RPD total; model/AIGC-specific caps  |
-| + API-Inference-enabled models | Varies  | Varies     | LLM, MLLM, AIGC  | Dynamic quotas + dynamic concurrency       |
-
-### [Nebius](https://studio.nebius.com/settings/api-keys) 🇳🇱
-
-$1 free signup credits, no credit card required. 60+ open-source models via OpenAI-compatible API. EU-based. [^10]
-
-Base URL: `https://api.studio.nebius.com/v1`
-
-| Model Name                   | Context | Max Output | Modality                       | Rate Limit |
-| ---------------------------- | ------- | ---------- | ------------------------------ | ---------- |
-| Meta-Llama-3.3-70B-Instruct  | 128K    | ~8K        | Text                           | Tier-based |
-| DeepSeek-V3-0324             | 128K    | ~8K        | Text                           | Tier-based |
-| DeepSeek-R1                  | 128K    | ~32K       | Text (reasoning)               | Tier-based |
-| Qwen3-235B-A22B              | 128K    | ~32K       | Text                           | Tier-based |
-| gpt-oss-120b                 | 128K    | ~32K       | Text                           | Tier-based |
-| + 55 more open-source models | Varies  | Varies     | Text, Vision, Code, Embeddings | Tier-based |
-
-### [Nscale](https://console.nscale.com/) 🇬🇧
-
-$5 free signup credits, no credit card required. EU-sovereign provider; data centers in Norway. "No rate limits, no cold starts." [^11]
-
-Base URL: `https://inference.api.nscale.com/v1`
-
-| Model Name                    | Context | Max Output | Modality         | Rate Limit |
-| ----------------------------- | ------- | ---------- | ---------------- | ---------- |
-| Llama-3.3-70B-Instruct        | 128K    | ~8K        | Text             | Fair-use   |
-| Qwen3-Coder-30B-A3B-Instruct  | 256K    | ~32K       | Text (code)      | Fair-use   |
-| DeepSeek-R1-Distill-Llama-70B | 128K    | ~32K       | Text (reasoning) | Fair-use   |
-| gpt-oss-120b                  | 128K    | ~32K       | Text             | Fair-use   |
-| Qwen3-32B                     | 128K    | ~32K       | Text             | Fair-use   |
+| Model Name                     | Context | Max Output | Modality  | Rate Limit                                 |
+| ------------------------------ | ------- | ---------- | --------- | ------------------------------------------ |
+| `Qwen/Qwen3.5-35B-A3B`         | —       | —          | Text      | 2,000 RPD total; <=500 RPD/model (dynamic) |
+| `Qwen/Qwen3.5-27B`             | —       | —          | Text      | 2,000 RPD total; <=500 RPD/model (dynamic) |
+| + API-Inference-enabled models | Varies  | Varies     | LLM, MLLM | Dynamic quotas + dynamic concurrency       |
 
 ### [NVIDIA NIM](https://build.nvidia.com/explore/discover) 🇺🇸
 
@@ -312,14 +223,13 @@ Base URL: `https://integrate.api.nvidia.com/v1`
 | Model Name                                | Context | Max Output | Modality                               | Rate Limit |
 | ----------------------------------------- | ------- | ---------- | -------------------------------------- | ---------- |
 | `deepseek-ai/deepseek-r1`                 | 128K    | ~163K      | Text (reasoning)                       | ~40 RPM    |
-| `nvidia/llama-3.1-nemotron-ultra-253b-v1` | 128K    | 4K         | Text                                   | ~40 RPM    |
 | `nvidia/nemotron-3-super-120b-a12b`       | 262K    | 262K       | Text                                   | ~40 RPM    |
 | `nvidia/nemotron-3-nano-30b-a3b`          | 128K    | 32K        | Text                                   | ~40 RPM    |
+| `nvidia/llama-3.1-nemotron-ultra-253b-v1` | 128K    | 4K         | Text                                   | ~40 RPM    |
 | `meta/llama-3.1-405b-instruct`            | 128K    | 4K         | Text                                   | ~40 RPM    |
 | `qwen/qwen2.5-72b-instruct`               | 128K    | 8K         | Text                                   | ~40 RPM    |
 | `google/gemma-4-31b`                      | 128K    | 8K         | Text                                   | ~40 RPM    |
 | `mistralai/mistral-large-2-instruct`      | 128K    | 4K         | Text                                   | ~40 RPM    |
-| `nvidia/nemotron-nano-2-vl`               | 128K    | 8K         | Vision + Text + Video                  | ~40 RPM    |
 | `minimax/minimax-m2.7`                    | 128K    | 8K         | Text                                   | ~40 RPM    |
 | + 90 more models                          | Varies  | Varies     | Text, Image, Video, Speech, Embeddings | ~40 RPM    |
 
@@ -341,49 +251,64 @@ Base URL: `https://api.ollama.com`
 
 ### [OpenRouter](https://openrouter.ai/keys) 🇺🇸
 
-~28 free models (marked with `:free` suffix). OpenAI SDK-compatible. [^4]
+~22 free models (marked with `:free` suffix). OpenAI SDK-compatible. [^4]
 
 Base URL: `https://openrouter.ai/api/v1`
 
-| Model Name                               | Context | Max Output | Modality         | Rate Limit     |
-| ---------------------------------------- | ------- | ---------- | ---------------- | -------------- |
-| `deepseek/deepseek-r1-0528:free`         | 163K    | ~163K      | Text (reasoning) | 20 RPM, 50 RPD |
-| `deepseek/deepseek-chat-v3.1:free`       | 163K    | 163K       | Text             | 20 RPM, 50 RPD |
-| `qwen/qwen3-235b-a22b:free`              | 128K    | ~32K       | Text             | 20 RPM, 50 RPD |
-| `qwen/qwen3-coder-480b-a35b:free`        | 262K    | ~32K       | Text (code)      | 20 RPM, 50 RPD |
-| `meta-llama/llama-4-scout:free`          | 10M     | 16K        | Multimodal       | 20 RPM, 50 RPD |
-| `meta-llama/llama-4-maverick:free`       | 1M      | 16K        | Multimodal       | 20 RPM, 50 RPD |
-| `meta-llama/llama-3.3-70b-instruct:free` | 65K     | ~16K       | Text             | 20 RPM, 50 RPD |
-| `google/gemma-4-31b-it:free`             | 256K    | ~8K        | Multimodal       | 20 RPM, 50 RPD |
-| `nvidia/nemotron-3-super-120b-a12b:free` | 1M      | ~32K       | Text             | 20 RPM, 50 RPD |
-| `openai/gpt-oss-120b:free`               | 131K    | 131K       | Text             | 20 RPM, 50 RPD |
-| `minimax/minimax-m2.5:free`              | 196K    | 8K         | Text             | 20 RPM, 50 RPD |
-| `mistralai/devstral-2512:free`           | 256K    | ~32K       | Text             | 20 RPM, 50 RPD |
-| + ~16 more free models                   | Varies  | Varies     | Text / Image     | 20 RPM, 50 RPD |
+| Model Name                                  | Context | Max Output | Modality     | Rate Limit      |
+| ------------------------------------------- | ------- | ---------- | ------------ | --------------- |
+| `qwen/qwen3-coder:free`                     | 1M      | 262K       | Text (code)  | 20 RPM, 200 RPD |
+| `nvidia/nemotron-3-ultra-550b-a55b:free`    | 1M      | 65K        | Text         | 20 RPM, 200 RPD |
+| `nvidia/nemotron-3-super-120b-a12b:free`    | 1M      | 262K       | Text         | 20 RPM, 200 RPD |
+| `openai/gpt-oss-120b:free`                  | 131K    | 131K       | Text         | 20 RPM, 200 RPD |
+| `openai/gpt-oss-20b:free`                   | 131K    | 8K         | Text         | 20 RPM, 200 RPD |
+| `meta-llama/llama-3.3-70b-instruct:free`    | 131K    | ~16K       | Text         | 20 RPM, 200 RPD |
+| `nousresearch/hermes-3-llama-3.1-405b:free` | 131K    | ~16K       | Text         | 20 RPM, 200 RPD |
+| `google/gemma-4-31b-it:free`                | 262K    | 32K        | Multimodal   | 20 RPM, 200 RPD |
+| `poolside/laguna-m.1:free`                  | 262K    | 32K        | Text         | 20 RPM, 200 RPD |
+| `qwen/qwen3-next-80b-a3b-instruct:free`     | 262K    | ~32K       | Text         | 20 RPM, 200 RPD |
+| + ~12 more free models                      | Varies  | Varies     | Text / Image | 20 RPM, 200 RPD |
 
-### [OVHcloud AI Endpoints](https://endpoints.ai.cloud.ovh.net/) 🇫🇷
+### [OVHcloud AI Endpoints](https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/) 🇫🇷
 
-Free anonymous tier (no API key, no signup): 2 RPM per IP per model. 40+ open-weight models hosted in EU. OpenAI SDK-compatible. [^7]
+Free anonymous tier (no API key, no signup): 2 RPM per IP per model. 20+ open-weight models hosted in EU. OpenAI SDK-compatible. [^7]
 
 Base URL: `https://oai.endpoints.kepler.ai.cloud.ovh.net/v1`
 
-| Model Name                    | Context | Max Output | Modality                          | Rate Limit        |
-| ----------------------------- | ------- | ---------- | --------------------------------- | ----------------- |
-| Meta-Llama-3_3-70B-Instruct   | 131K    | ~4K        | Text                              | 2 RPM (anonymous) |
-| Meta-Llama-3_1-8B-Instruct    | 131K    | ~4K        | Text                              | 2 RPM (anonymous) |
-| DeepSeek-R1-Distill-Llama-70B | 131K    | ~32K       | Text (reasoning)                  | 2 RPM (anonymous) |
-| Qwen3-32B                     | 131K    | ~32K       | Text                              | 2 RPM (anonymous) |
-| Qwen3-Coder-30B-A3B-Instruct  | 262K    | ~32K       | Text (code)                       | 2 RPM (anonymous) |
-| Qwen2.5-VL-72B-Instruct       | 128K    | ~8K        | Text + Vision                     | 2 RPM (anonymous) |
-| Mixtral-8x7B-Instruct-v0.1    | 32K     | ~4K        | Text                              | 2 RPM (anonymous) |
-| Mistral-Nemo-Instruct-2407    | 128K    | ~4K        | Text                              | 2 RPM (anonymous) |
-| Qwen3Guard-Gen-8B             | 32K     | ~4K        | Text (safety guard)               | 2 RPM (anonymous) |
-| Qwen3Guard-Gen-0.6B           | 32K     | ~4K        | Text (safety guard)               | 2 RPM (anonymous) |
-| + 30 more models              | Varies  | Varies     | Text, Vision, Code, Image, Speech | 2 RPM (anonymous) |
+| Model Name                     | Context | Max Output | Modality      | Rate Limit        |
+| ------------------------------ | ------- | ---------- | ------------- | ----------------- |
+| Qwen3.5-397B-A17B              | 131K    | ~32K       | Text          | 2 RPM (anonymous) |
+| gpt-oss-120b                   | 128K    | ~32K       | Text          | 2 RPM (anonymous) |
+| gpt-oss-20b                    | 128K    | ~8K        | Text          | 2 RPM (anonymous) |
+| Meta-Llama-3_3-70B-Instruct    | 131K    | ~4K        | Text          | 2 RPM (anonymous) |
+| Llama-3.1-8B-Instruct          | 131K    | ~4K        | Text          | 2 RPM (anonymous) |
+| Qwen3.6-27B                    | 131K    | ~32K       | Text          | 2 RPM (anonymous) |
+| Qwen3.5-9B                     | 131K    | ~8K        | Text          | 2 RPM (anonymous) |
+| Qwen3-32B                      | 131K    | ~32K       | Text          | 2 RPM (anonymous) |
+| Qwen3-Coder-30B-A3B-Instruct   | 262K    | ~32K       | Text (code)   | 2 RPM (anonymous) |
+| Qwen2.5-VL-72B-Instruct        | 128K    | ~8K        | Text + Vision | 2 RPM (anonymous) |
+| Mistral-Small-3.2-24B-Instruct | 128K    | ~4K        | Text          | 2 RPM (anonymous) |
+| Mistral-Nemo-Instruct-2407     | 128K    | ~4K        | Text          | 2 RPM (anonymous) |
+| Mistral-7B-Instruct-v0.3       | 32K     | ~4K        | Text          | 2 RPM (anonymous) |
+
+### [SambaNova](https://cloud.sambanova.ai/apis) 🇺🇸
+
+Free tier, no credit card. Ultra-fast RDU inference. 20 RPM, 200K tokens/day. [^8]
+
+Base URL: `https://api.sambanova.ai/v1`
+
+| Model Name                  | Context | Max Output | Modality | Rate Limit               |
+| --------------------------- | ------- | ---------- | -------- | ------------------------ |
+| DeepSeek-V3.1               | 128K    | ~8K        | Text     | 20 RPM, 20 RPD, 200K TPD |
+| DeepSeek-V3.2 (Preview)     | 128K    | ~8K        | Text     | 20 RPM, 20 RPD, 200K TPD |
+| Meta-Llama-3.3-70B-Instruct | 128K    | ~8K        | Text     | 20 RPM, 20 RPD, 200K TPD |
+| gpt-oss-120b                | 128K    | ~8K        | Text     | 20 RPM, 20 RPD, 200K TPD |
+| MiniMax-M2.7                | 128K    | ~8K        | Text     | 20 RPM, 20 RPD, 200K TPD |
+| gemma-4-31B-it (Preview)    | 128K    | ~8K        | Text     | 20 RPM, 20 RPD, 200K TPD |
 
 ### [SiliconFlow](https://cloud.siliconflow.cn/account/ak) 🇨🇳
 
-3 permanently free models. Free tier capped at 50 req/day; ≥10 CNY lifetime purchase raises cap to 1,000/day. 200+ paid models also available.
+Permanently free models, no credit card required. 200+ paid models also available.
 
 Base URL: `https://api.siliconflow.cn/v1`
 
@@ -391,7 +316,6 @@ Base URL: `https://api.siliconflow.cn/v1`
 | ----------------------------------------- | ------- | ------------ | ---------------- | --------------- |
 | `Qwen/Qwen3-8B`                           | 131K    | 131K         | Text             | 30 RPM, 60K TPM |
 | `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B` | 131K    | Configurable | Text (reasoning) | 30 RPM, 60K TPM |
-| `deepseek-ai/DeepSeek-OCR`                | —       | 8K           | Vision (OCR)     | 30 RPM, 60K TPM |
 
 ## Glossary
 
@@ -408,14 +332,10 @@ Base URL: `https://api.siliconflow.cn/v1`
 Know a free tier that's missing? [Open a PR](contributing.md). Include the provider, endpoint, rate limits (link to their docs), and a few notable models. Trial credits and time-limited promos don't count.
 
 [^1]: Free tier not available in the EU, UK, or Switzerland ([available regions](https://ai.google.dev/gemini-api/docs/available-regions)).
-[^2]: Groq rate limits vary by model. Llama 4 Maverick is limited to 500 RPD. Most other models get 14,400 RPD ([rate limits](https://console.groq.com/docs/rate-limits)).
+[^2]: Groq rate limits were reduced in 2026. Most models now get 1,000 RPD on the free tier (down from 14,400). Llama 4 Maverick has been deprecated. See [rate limits](https://console.groq.com/docs/rate-limits).
 [^3]: Ollama Cloud measures usage by GPU time, not tokens or requests. Free tier described as "light usage" with session limits resetting every 5 hours and weekly limits every 7 days. Pro (50x more) and Max (250x more) plans available. Not OpenAI SDK-compatible; uses the Ollama API.
-[^4]: Free models default to 50 RPD per model. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order. Free providers may log prompts for training.
+[^4]: Free models default to 200 RPD per model. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order. Free providers may log prompts for training.
 [^5]: Kilo Code free model list may change over time. nvidia/nemotron-3-super-120b-a12b:free is for trial use only — prompts are logged by NVIDIA. Auto-router `kilo-auto/free` routes to minimax/minimax-m2.5:free (80%) and stepfun/step-3.5-flash:free (20%).
 [^6]: API-Inference is free for registered users. Current published limits are 2,000 requests/day per user (total across models), with per-model daily quotas dynamically adjusted and capped at 500; concurrency is also dynamically rate-limited. Requires Alibaba Cloud account binding and real-name verification ([limits](https://modelscope.cn/docs/model-service/API-Inference/limits), [intro](https://modelscope.cn/docs/model-service/API-Inference/intro)).
-[^7]: OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required — click "Get your free token" on the OVHcloud AI Endpoints site. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers.
-[^8]: Free quota is signup-only with 90-day expiration and only granted in the Singapore / International region. Alibaba Cloud account requires phone/email verification but no credit card. After exhaustion, pay-as-you-go applies. Use the international endpoint `dashscope-intl.aliyuncs.com`; the China region (`dashscope.aliyuncs.com`) requires real-name verification.
-[^9]: DeepSeek grants 5M free tokens at signup with a 30-day expiration. After expiry, pay-as-you-go applies. No credit card required at signup; prompts may be used to improve models unless explicitly opted out in account settings.
-[^10]: Nebius grants $1 in free credits at signup, usable without a payment method. Credit card required to top up after exhaustion. Promo codes have expiration dates; the base $1 credit typically does not expire.
-[^11]: Nscale grants $5 in free signup credits with no credit card required. Credits typically expire within 30–90 days (check console). Credit card required to top up. Pay-per-token after free credits exhausted. EU-sovereign, with data centers in Norway.
-[^12]: xAI's $25 sign-up credit is one-time. Users who opt into the data-sharing program (prompts logged) receive an additional $150/month in credits, but the program requires $5 of prior spend before activation, so it is not a pure free tier. Several older Grok models (grok-4, grok-4-fast, grok-4-1-fast) were retired on May 15, 2026 and now redirect to grok-4.3 ([models](https://docs.x.ai/developers/models)).
+[^7]: OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers.
+[^8]: SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible.

--- a/data.json
+++ b/data.json
@@ -1,83 +1,39 @@
 {
-  "lastUpdated": "2026-05-20",
+  "lastUpdated": "2026-06-15",
   "providers": [
     {
-      "name": "AI21 Labs",
+      "name": "Aion Labs",
       "category": "provider_api",
       "country": "IL",
       "flag": "🇮🇱",
-      "url": "https://studio.ai21.com/account/api-key",
-      "baseUrl": "https://api.ai21.com/studio/v1",
-      "description": "$10 trial credits at signup, no credit card. Credits expire in 3 months. Covers Jamba Large and Jamba Mini.",
+      "url": "https://www.aionlabs.ai",
+      "baseUrl": "https://api.aionlabs.ai/v1",
+      "description": "Permanent free tier, no credit card required. 15 RPM, 20K tokens/day. Specialized for roleplay and storytelling.",
       "footnoteRef": null,
       "models": [
         {
-          "id": "jamba-large",
-          "name": "Jamba Large 1.7",
-          "context": "256K",
-          "maxOutput": "4K",
-          "modality": "Text",
-          "rateLimit": "200 RPM, 10 RPS"
-        },
-        {
-          "id": "jamba-mini",
-          "name": "Jamba Mini 2",
-          "context": "256K",
-          "maxOutput": "4K",
-          "modality": "Text",
-          "rateLimit": "200 RPM, 10 RPS"
-        }
-      ]
-    },
-    {
-      "name": "Alibaba Cloud Model Studio",
-      "category": "provider_api",
-      "country": "CN",
-      "flag": "🇨🇳",
-      "url": "https://bailian.console.alibabacloud.com/?apiKey=1",
-      "baseUrl": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-      "description": "1M free tokens per Qwen model on signup, expires in 90 days (International / Singapore region). No credit card required.",
-      "footnoteRef": 8,
-      "models": [
-        {
-          "id": "qwen3-max",
-          "name": "Qwen3-Max",
+          "id": "aion-2.5",
+          "name": "Aion 2.5",
           "context": "128K",
           "maxOutput": "32K",
-          "modality": "Text",
-          "rateLimit": "Tiered by region"
+          "modality": "Text (roleplay)",
+          "rateLimit": "15 RPM, 20K TPD"
         },
         {
-          "id": "qwen3-plus",
-          "name": "Qwen3-Plus",
-          "context": "1M",
-          "maxOutput": "32K",
-          "modality": "Text",
-          "rateLimit": "Tiered by region"
-        },
-        {
-          "id": "qwen3-vl-plus",
-          "name": "Qwen3-VL-Plus",
+          "id": "aion-2.0",
+          "name": "Aion 2.0",
           "context": "128K",
-          "maxOutput": "8K",
-          "modality": "Text + Vision",
-          "rateLimit": "Tiered by region"
-        },
-        {
-          "id": "qwen3-coder-plus",
-          "name": "Qwen3-Coder-Plus",
-          "context": "256K",
-          "maxOutput": "8K",
-          "modality": "Text (code)",
-          "rateLimit": "Tiered by region"
-        },
-        {
-          "id": "qwq-plus",
-          "name": "QwQ-Plus",
-          "context": "131K",
           "maxOutput": "32K",
-          "modality": "Text (reasoning)",
-          "rateLimit": "Tiered by region"
+          "modality": "Text (roleplay)",
+          "rateLimit": "15 RPM, 20K TPD"
+        },
+        {
+          "id": "aion-rp-llama-3.1-8b",
+          "name": "Aion-RP 1.0 (8B)",
+          "context": "32K",
+          "maxOutput": "~8K",
+          "modality": "Text (roleplay)",
+          "rateLimit": "15 RPM, 20K TPD"
         }
       ]
     },
@@ -91,6 +47,14 @@
       "description": "Free \"Trial\" API key, no credit card. 1,000 API calls/month. Non-commercial use only.",
       "footnoteRef": null,
       "models": [
+        {
+          "id": "command-a-plus-05-2026",
+          "name": "Command A+ (218B)",
+          "context": "128K",
+          "maxOutput": "4K",
+          "modality": "Text",
+          "rateLimit": "20 RPM"
+        },
         {
           "id": "command-a-03-2025",
           "name": "Command A (111B)",
@@ -122,50 +86,6 @@
           "maxOutput": "4K",
           "modality": "Text",
           "rateLimit": "20 RPM"
-        },
-        {
-          "id": "embed-v4.0",
-          "name": "Embed 4",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Embeddings (Text + Image)",
-          "rateLimit": "2,000 inputs/min"
-        },
-        {
-          "id": "rerank-v3.5",
-          "name": "Rerank 3.5",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Reranking",
-          "rateLimit": "10 RPM"
-        }
-      ]
-    },
-    {
-      "name": "DeepSeek",
-      "category": "provider_api",
-      "country": "CN",
-      "flag": "🇨🇳",
-      "url": "https://platform.deepseek.com/api_keys",
-      "baseUrl": "https://api.deepseek.com/v1",
-      "description": "5M free tokens on signup, no credit card. Credits expire 30 days after signup; pay-as-you-go after. Prompts may be used for training unless opted out.",
-      "footnoteRef": 9,
-      "models": [
-        {
-          "id": "deepseek-chat",
-          "name": "deepseek-chat (V3.2)",
-          "context": "128K",
-          "maxOutput": "8K",
-          "modality": "Text",
-          "rateLimit": "Dynamic"
-        },
-        {
-          "id": "deepseek-reasoner",
-          "name": "deepseek-reasoner (R1)",
-          "context": "128K",
-          "maxOutput": "8K",
-          "modality": "Text (reasoning)",
-          "rateLimit": "Dynamic"
         }
       ]
     },
@@ -180,12 +100,20 @@
       "footnoteRef": 1,
       "models": [
         {
-          "id": "gemini-2.5-pro",
-          "name": "Gemini 2.5 Pro",
-          "context": "2M",
+          "id": "gemini-3.5-flash",
+          "name": "Gemini 3.5 Flash",
+          "context": "1M",
+          "maxOutput": "64K",
+          "modality": "Text + Image + Audio + Video",
+          "rateLimit": "15 RPM, 1,500 RPD"
+        },
+        {
+          "id": "gemini-3.1-flash-lite",
+          "name": "Gemini 3.1 Flash-Lite",
+          "context": "1M",
           "maxOutput": "65K",
           "modality": "Text + Image + Audio + Video",
-          "rateLimit": "5 RPM, 100 RPD"
+          "rateLimit": "30 RPM, 1,500 RPD"
         },
         {
           "id": "gemini-2.5-flash",
@@ -193,23 +121,15 @@
           "context": "1M",
           "maxOutput": "65K",
           "modality": "Text + Image + Audio + Video",
-          "rateLimit": "10 RPM, 250 RPD"
+          "rateLimit": "15 RPM, 1,500 RPD"
         },
         {
-          "id": "gemini-2.5-flash-lite",
-          "name": "Gemini 2.5 Flash-Lite",
-          "context": "1M",
+          "id": "gemini-2.5-pro",
+          "name": "Gemini 2.5 Pro",
+          "context": "2M",
           "maxOutput": "65K",
           "modality": "Text + Image + Audio + Video",
-          "rateLimit": "15 RPM, 1,000 RPD"
-        },
-        {
-          "id": "gemini-3-flash-preview",
-          "name": "Gemini 3 Flash (Preview)",
-          "context": "1M",
-          "maxOutput": "65K",
-          "modality": "Text + Image + Audio + Video",
-          "rateLimit": "Preview limits"
+          "rateLimit": "5 RPM, 50 RPD"
         }
       ]
     },
@@ -224,19 +144,19 @@
       "footnoteRef": null,
       "models": [
         {
-          "id": "mistral-small-2603",
-          "name": "Mistral Small 4",
+          "id": "mistral-medium-2604",
+          "name": "Mistral Medium 3.5 (128B)",
           "context": "256K",
           "maxOutput": "256K",
           "modality": "Text + Image + Code",
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
-          "id": "mistral-medium-2505",
-          "name": "Mistral Medium 3",
-          "context": "128K",
-          "maxOutput": "128K",
-          "modality": "Text",
+          "id": "mistral-small-2603",
+          "name": "Mistral Small 4",
+          "context": "256K",
+          "maxOutput": "256K",
+          "modality": "Text + Image + Code",
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
@@ -292,14 +212,6 @@
           "rateLimit": "1 concurrent request"
         },
         {
-          "id": "glm-4.5-flash",
-          "name": "GLM-4.5-Flash",
-          "context": "128K",
-          "maxOutput": "~8K",
-          "modality": "Text",
-          "rateLimit": "1 concurrent request"
-        },
-        {
           "id": "glm-4.6v-flash",
           "name": "GLM-4.6V-Flash",
           "context": "128K",
@@ -316,47 +228,15 @@
       "flag": "🇺🇸",
       "url": "https://cloud.cerebras.ai/",
       "baseUrl": "https://api.cerebras.ai/v1",
-      "description": "Free tier, no credit card. Ultra-fast inference (~2,600 tok/s). 1M tokens/day cap. 8K context cap on free tier. llama3.1-8b scheduled for deprecation May 27, 2026.",
+      "description": "Free tier, no credit card. Ultra-fast inference (~2,600 tok/s). 1M tokens/day cap. 8K context cap on free tier.",
       "footnoteRef": null,
       "models": [
-        {
-          "id": "llama-3.3-70b",
-          "name": "llama-3.3-70b",
-          "context": "128K (8K on free)",
-          "maxOutput": "8K",
-          "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD, 1M TPD"
-        },
         {
           "id": "gpt-oss-120b",
           "name": "gpt-oss-120b",
           "context": "128K (8K on free)",
           "maxOutput": "8K",
           "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD, 1M TPD"
-        },
-        {
-          "id": "qwen-3-235b-a22b-instruct-2507",
-          "name": "qwen-3-235b-a22b-instruct-2507",
-          "context": "131K (8K on free)",
-          "maxOutput": "8K",
-          "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD, 1M TPD"
-        },
-        {
-          "id": "qwen-3-32b",
-          "name": "qwen-3-32b",
-          "context": "131K (8K on free)",
-          "maxOutput": "8K",
-          "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD, 1M TPD"
-        },
-        {
-          "id": "llama-4-scout-17b-16e-instruct",
-          "name": "llama-4-scout-17b-16e-instruct",
-          "context": "128K (8K on free)",
-          "maxOutput": "8K",
-          "modality": "Text + Vision",
           "rateLimit": "30 RPM, 14,400 RPD, 1M TPD"
         },
         {
@@ -388,22 +268,6 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
-          "id": "@cf/meta/llama-3.1-8b-instruct-fp8-fast",
-          "name": "@cf/meta/llama-3.1-8b-instruct-fp8-fast",
-          "context": "131K",
-          "maxOutput": "Shared w/ context",
-          "modality": "Text",
-          "rateLimit": "10K neurons/day (shared)"
-        },
-        {
-          "id": "@cf/meta/llama-3.2-11b-vision-instruct",
-          "name": "@cf/meta/llama-3.2-11b-vision-instruct",
-          "context": "131K",
-          "maxOutput": "Shared w/ context",
-          "modality": "Text + Vision",
-          "rateLimit": "10K neurons/day (shared)"
-        },
-        {
           "id": "@cf/meta/llama-4-scout-17b-16e-instruct",
           "name": "@cf/meta/llama-4-scout-17b-16e-instruct",
           "context": "Up to 10M",
@@ -412,11 +276,19 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
-          "id": "@cf/mistralai/mistral-small-3.1-24b-instruct",
-          "name": "@cf/mistralai/mistral-small-3.1-24b-instruct",
+          "id": "@cf/openai/gpt-oss-120b",
+          "name": "@cf/openai/gpt-oss-120b",
           "context": "128K",
           "maxOutput": "Shared w/ context",
           "modality": "Text",
+          "rateLimit": "10K neurons/day (shared)"
+        },
+        {
+          "id": "@cf/moonshotai/kimi-k2.7-code",
+          "name": "@cf/moonshotai/kimi-k2.7-code",
+          "context": "262K",
+          "maxOutput": "Shared w/ context",
+          "modality": "Text (code)",
           "rateLimit": "10K neurons/day (shared)"
         },
         {
@@ -428,11 +300,19 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
-          "id": "@cf/moonshotai/kimi-k2.5",
-          "name": "@cf/moonshotai/kimi-k2.5",
-          "context": "256K",
+          "id": "@cf/zhipuai/glm-4.7-flash",
+          "name": "@cf/zhipuai/glm-4.7-flash",
+          "context": "131K",
           "maxOutput": "Shared w/ context",
-          "modality": "Text + Vision",
+          "modality": "Text",
+          "rateLimit": "10K neurons/day (shared)"
+        },
+        {
+          "id": "@cf/mistralai/mistral-small-3.1-24b-instruct",
+          "name": "@cf/mistralai/mistral-small-3.1-24b-instruct",
+          "context": "128K",
+          "maxOutput": "Shared w/ context",
+          "modality": "Text",
           "rateLimit": "10K neurons/day (shared)"
         },
         {
@@ -569,7 +449,7 @@
           "context": "131K",
           "maxOutput": "32K",
           "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD"
+          "rateLimit": "30 RPM, 1,000 RPD"
         },
         {
           "id": "llama-3.1-8b-instant",
@@ -577,7 +457,7 @@
           "context": "131K",
           "maxOutput": "131K",
           "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD"
+          "rateLimit": "30 RPM, 1,000 RPD"
         },
         {
           "id": "llama-4-scout-17b-16e-instruct",
@@ -585,15 +465,7 @@
           "context": "131K",
           "maxOutput": "8K",
           "modality": "Text + Vision",
-          "rateLimit": "30 RPM, 14,400 RPD"
-        },
-        {
-          "id": "llama-4-maverick-17b-128e-instruct",
-          "name": "llama-4-maverick-17b-128e-instruct",
-          "context": "131K",
-          "maxOutput": "8K",
-          "modality": "Text + Vision",
-          "rateLimit": "15 RPM, 500 RPD"
+          "rateLimit": "30 RPM, 1,000 RPD"
         },
         {
           "id": "qwen3-32b",
@@ -601,7 +473,7 @@
           "context": "131K",
           "maxOutput": "131K",
           "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD"
+          "rateLimit": "30 RPM, 1,000 RPD"
         },
         {
           "id": "gpt-oss-120b",
@@ -609,39 +481,7 @@
           "context": "131K",
           "maxOutput": "32K",
           "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD"
-        },
-        {
-          "id": "kimi-k2-instruct",
-          "name": "kimi-k2-instruct",
-          "context": "262K",
-          "maxOutput": "262K",
-          "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD"
-        },
-        {
-          "id": "deepseek-r1-distill-70b",
-          "name": "deepseek-r1-distill-70b",
-          "context": "131K",
-          "maxOutput": "8K",
-          "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD"
-        },
-        {
-          "id": "whisper-large-v3",
-          "name": "whisper-large-v3",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Audio → Text",
-          "rateLimit": "20 RPM, 2,000 RPD"
-        },
-        {
-          "id": "whisper-large-v3-turbo",
-          "name": "whisper-large-v3-turbo",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Audio → Text",
-          "rateLimit": "20 RPM, 2,000 RPD"
+          "rateLimit": "30 RPM, 1,000 RPD"
         }
       ]
     },
@@ -848,7 +688,7 @@
           "name": "Qwen/Qwen3.5-35B-A3B",
           "context": "—",
           "maxOutput": "—",
-          "modality": "Text + Vision",
+          "modality": "Text",
           "rateLimit": "2,000 RPD total; <=500 RPD/model (dynamic)"
         },
         {
@@ -860,132 +700,12 @@
           "rateLimit": "2,000 RPD total; <=500 RPD/model (dynamic)"
         },
         {
-          "id": "Qwen/Qwen-Image",
-          "name": "Qwen/Qwen-Image",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Image Generation",
-          "rateLimit": "2,000 RPD total; model/AIGC-specific caps"
-        },
-        {
           "id": null,
           "name": "+ API-Inference-enabled models",
           "context": "Varies",
           "maxOutput": "Varies",
-          "modality": "LLM, MLLM, AIGC",
+          "modality": "LLM, MLLM",
           "rateLimit": "Dynamic quotas + dynamic concurrency"
-        }
-      ]
-    },
-    {
-      "name": "Nebius",
-      "category": "inference_provider",
-      "country": "NL",
-      "flag": "🇳🇱",
-      "url": "https://studio.nebius.com/settings/api-keys",
-      "baseUrl": "https://api.studio.nebius.com/v1",
-      "description": "$1 free signup credits, no credit card required. 60+ open-source models via OpenAI-compatible API. EU-based.",
-      "footnoteRef": 10,
-      "models": [
-        {
-          "id": "meta-llama/Meta-Llama-3.3-70B-Instruct",
-          "name": "Meta-Llama-3.3-70B-Instruct",
-          "context": "128K",
-          "maxOutput": "~8K",
-          "modality": "Text",
-          "rateLimit": "Tier-based"
-        },
-        {
-          "id": "deepseek-ai/DeepSeek-V3-0324",
-          "name": "DeepSeek-V3-0324",
-          "context": "128K",
-          "maxOutput": "~8K",
-          "modality": "Text",
-          "rateLimit": "Tier-based"
-        },
-        {
-          "id": "deepseek-ai/DeepSeek-R1",
-          "name": "DeepSeek-R1",
-          "context": "128K",
-          "maxOutput": "~32K",
-          "modality": "Text (reasoning)",
-          "rateLimit": "Tier-based"
-        },
-        {
-          "id": "Qwen/Qwen3-235B-A22B",
-          "name": "Qwen3-235B-A22B",
-          "context": "128K",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "Tier-based"
-        },
-        {
-          "id": "openai/gpt-oss-120b",
-          "name": "gpt-oss-120b",
-          "context": "128K",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "Tier-based"
-        },
-        {
-          "id": null,
-          "name": "+ 55 more open-source models",
-          "context": "Varies",
-          "maxOutput": "Varies",
-          "modality": "Text, Vision, Code, Embeddings",
-          "rateLimit": "Tier-based"
-        }
-      ]
-    },
-    {
-      "name": "Nscale",
-      "category": "inference_provider",
-      "country": "GB",
-      "flag": "🇬🇧",
-      "url": "https://console.nscale.com/",
-      "baseUrl": "https://inference.api.nscale.com/v1",
-      "description": "$5 free signup credits, no credit card required. EU-sovereign provider; data centers in Norway. \"No rate limits, no cold starts.\"",
-      "footnoteRef": 11,
-      "models": [
-        {
-          "id": "meta-llama/Llama-3.3-70B-Instruct",
-          "name": "Llama-3.3-70B-Instruct",
-          "context": "128K",
-          "maxOutput": "~8K",
-          "modality": "Text",
-          "rateLimit": "Fair-use"
-        },
-        {
-          "id": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
-          "name": "Qwen3-Coder-30B-A3B-Instruct",
-          "context": "256K",
-          "maxOutput": "~32K",
-          "modality": "Text (code)",
-          "rateLimit": "Fair-use"
-        },
-        {
-          "id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-          "name": "DeepSeek-R1-Distill-Llama-70B",
-          "context": "128K",
-          "maxOutput": "~32K",
-          "modality": "Text (reasoning)",
-          "rateLimit": "Fair-use"
-        },
-        {
-          "id": "openai/gpt-oss-120b",
-          "name": "gpt-oss-120b",
-          "context": "128K",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "Fair-use"
-        },
-        {
-          "id": "Qwen/Qwen3-32B",
-          "name": "Qwen3-32B",
-          "context": "128K",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "Fair-use"
         }
       ]
     },
@@ -1008,14 +728,6 @@
           "rateLimit": "~40 RPM"
         },
         {
-          "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-          "name": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-          "context": "128K",
-          "maxOutput": "4K",
-          "modality": "Text",
-          "rateLimit": "~40 RPM"
-        },
-        {
           "id": "nvidia/nemotron-3-super-120b-a12b",
           "name": "nvidia/nemotron-3-super-120b-a12b",
           "context": "262K",
@@ -1028,6 +740,14 @@
           "name": "nvidia/nemotron-3-nano-30b-a3b",
           "context": "128K",
           "maxOutput": "32K",
+          "modality": "Text",
+          "rateLimit": "~40 RPM"
+        },
+        {
+          "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+          "name": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+          "context": "128K",
+          "maxOutput": "4K",
           "modality": "Text",
           "rateLimit": "~40 RPM"
         },
@@ -1061,14 +781,6 @@
           "context": "128K",
           "maxOutput": "4K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
-        },
-        {
-          "id": "nvidia/nemotron-nano-2-vl",
-          "name": "nvidia/nemotron-nano-2-vl",
-          "context": "128K",
-          "maxOutput": "8K",
-          "modality": "Vision + Text + Video",
           "rateLimit": "~40 RPM"
         },
         {
@@ -1164,80 +876,32 @@
       "flag": "🇺🇸",
       "url": "https://openrouter.ai/keys",
       "baseUrl": "https://openrouter.ai/api/v1",
-      "description": "~28 free models (marked with `:free` suffix). OpenAI SDK-compatible.",
+      "description": "~22 free models (marked with `:free` suffix). OpenAI SDK-compatible.",
       "footnoteRef": 4,
       "models": [
         {
-          "id": "deepseek/deepseek-r1-0528:free",
-          "name": "deepseek/deepseek-r1-0528:free",
-          "context": "163K",
-          "maxOutput": "~163K",
-          "modality": "Text (reasoning)",
-          "rateLimit": "20 RPM, 50 RPD"
-        },
-        {
-          "id": "deepseek/deepseek-chat-v3.1:free",
-          "name": "deepseek/deepseek-chat-v3.1:free",
-          "context": "163K",
-          "maxOutput": "163K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 50 RPD"
-        },
-        {
-          "id": "qwen/qwen3-235b-a22b:free",
-          "name": "qwen/qwen3-235b-a22b:free",
-          "context": "128K",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 50 RPD"
-        },
-        {
-          "id": "qwen/qwen3-coder-480b-a35b:free",
-          "name": "qwen/qwen3-coder-480b-a35b:free",
-          "context": "262K",
-          "maxOutput": "~32K",
-          "modality": "Text (code)",
-          "rateLimit": "20 RPM, 50 RPD"
-        },
-        {
-          "id": "meta-llama/llama-4-scout:free",
-          "name": "meta-llama/llama-4-scout:free",
-          "context": "10M",
-          "maxOutput": "16K",
-          "modality": "Multimodal",
-          "rateLimit": "20 RPM, 50 RPD"
-        },
-        {
-          "id": "meta-llama/llama-4-maverick:free",
-          "name": "meta-llama/llama-4-maverick:free",
+          "id": "qwen/qwen3-coder:free",
+          "name": "qwen/qwen3-coder:free",
           "context": "1M",
-          "maxOutput": "16K",
-          "modality": "Multimodal",
-          "rateLimit": "20 RPM, 50 RPD"
+          "maxOutput": "262K",
+          "modality": "Text (code)",
+          "rateLimit": "20 RPM, 200 RPD"
         },
         {
-          "id": "meta-llama/llama-3.3-70b-instruct:free",
-          "name": "meta-llama/llama-3.3-70b-instruct:free",
-          "context": "65K",
-          "maxOutput": "~16K",
+          "id": "nvidia/nemotron-3-ultra-550b-a55b:free",
+          "name": "nvidia/nemotron-3-ultra-550b-a55b:free",
+          "context": "1M",
+          "maxOutput": "65K",
           "modality": "Text",
-          "rateLimit": "20 RPM, 50 RPD"
-        },
-        {
-          "id": "google/gemma-4-31b-it:free",
-          "name": "google/gemma-4-31b-it:free",
-          "context": "256K",
-          "maxOutput": "~8K",
-          "modality": "Multimodal",
-          "rateLimit": "20 RPM, 50 RPD"
+          "rateLimit": "20 RPM, 200 RPD"
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b:free",
           "name": "nvidia/nemotron-3-super-120b-a12b:free",
           "context": "1M",
-          "maxOutput": "~32K",
+          "maxOutput": "262K",
           "modality": "Text",
-          "rateLimit": "20 RPM, 50 RPD"
+          "rateLimit": "20 RPM, 200 RPD"
         },
         {
           "id": "openai/gpt-oss-120b:free",
@@ -1245,31 +909,63 @@
           "context": "131K",
           "maxOutput": "131K",
           "modality": "Text",
-          "rateLimit": "20 RPM, 50 RPD"
+          "rateLimit": "20 RPM, 200 RPD"
         },
         {
-          "id": "minimax/minimax-m2.5:free",
-          "name": "minimax/minimax-m2.5:free",
-          "context": "196K",
+          "id": "openai/gpt-oss-20b:free",
+          "name": "openai/gpt-oss-20b:free",
+          "context": "131K",
           "maxOutput": "8K",
           "modality": "Text",
-          "rateLimit": "20 RPM, 50 RPD"
+          "rateLimit": "20 RPM, 200 RPD"
         },
         {
-          "id": "mistralai/devstral-2512:free",
-          "name": "mistralai/devstral-2512:free",
-          "context": "256K",
+          "id": "meta-llama/llama-3.3-70b-instruct:free",
+          "name": "meta-llama/llama-3.3-70b-instruct:free",
+          "context": "131K",
+          "maxOutput": "~16K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 200 RPD"
+        },
+        {
+          "id": "nousresearch/hermes-3-llama-3.1-405b:free",
+          "name": "nousresearch/hermes-3-llama-3.1-405b:free",
+          "context": "131K",
+          "maxOutput": "~16K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 200 RPD"
+        },
+        {
+          "id": "google/gemma-4-31b-it:free",
+          "name": "google/gemma-4-31b-it:free",
+          "context": "262K",
+          "maxOutput": "32K",
+          "modality": "Multimodal",
+          "rateLimit": "20 RPM, 200 RPD"
+        },
+        {
+          "id": "poolside/laguna-m.1:free",
+          "name": "poolside/laguna-m.1:free",
+          "context": "262K",
+          "maxOutput": "32K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 200 RPD"
+        },
+        {
+          "id": "qwen/qwen3-next-80b-a3b-instruct:free",
+          "name": "qwen/qwen3-next-80b-a3b-instruct:free",
+          "context": "262K",
           "maxOutput": "~32K",
           "modality": "Text",
-          "rateLimit": "20 RPM, 50 RPD"
+          "rateLimit": "20 RPM, 200 RPD"
         },
         {
           "id": null,
-          "name": "+ ~16 more free models",
+          "name": "+ ~12 more free models",
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text / Image",
-          "rateLimit": "20 RPM, 50 RPD"
+          "rateLimit": "20 RPM, 200 RPD"
         }
       ]
     },
@@ -1278,11 +974,35 @@
       "category": "inference_provider",
       "country": "FR",
       "flag": "🇫🇷",
-      "url": "https://endpoints.ai.cloud.ovh.net/",
+      "url": "https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/",
       "baseUrl": "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
-      "description": "Free anonymous tier (no API key, no signup): 2 RPM per IP per model. 40+ open-weight models hosted in EU. OpenAI SDK-compatible.",
+      "description": "Free anonymous tier (no API key, no signup): 2 RPM per IP per model. 20+ open-weight models hosted in EU. OpenAI SDK-compatible.",
       "footnoteRef": 7,
       "models": [
+        {
+          "id": "Qwen3.5-397B-A17B",
+          "name": "Qwen3.5-397B-A17B",
+          "context": "131K",
+          "maxOutput": "~32K",
+          "modality": "Text",
+          "rateLimit": "2 RPM (anonymous)"
+        },
+        {
+          "id": "gpt-oss-120b",
+          "name": "gpt-oss-120b",
+          "context": "128K",
+          "maxOutput": "~32K",
+          "modality": "Text",
+          "rateLimit": "2 RPM (anonymous)"
+        },
+        {
+          "id": "gpt-oss-20b",
+          "name": "gpt-oss-20b",
+          "context": "128K",
+          "maxOutput": "~8K",
+          "modality": "Text",
+          "rateLimit": "2 RPM (anonymous)"
+        },
         {
           "id": "Meta-Llama-3_3-70B-Instruct",
           "name": "Meta-Llama-3_3-70B-Instruct",
@@ -1292,19 +1012,27 @@
           "rateLimit": "2 RPM (anonymous)"
         },
         {
-          "id": "Meta-Llama-3_1-8B-Instruct",
-          "name": "Meta-Llama-3_1-8B-Instruct",
+          "id": "Llama-3.1-8B-Instruct",
+          "name": "Llama-3.1-8B-Instruct",
           "context": "131K",
           "maxOutput": "~4K",
           "modality": "Text",
           "rateLimit": "2 RPM (anonymous)"
         },
         {
-          "id": "DeepSeek-R1-Distill-Llama-70B",
-          "name": "DeepSeek-R1-Distill-Llama-70B",
+          "id": "Qwen3.6-27B",
+          "name": "Qwen3.6-27B",
           "context": "131K",
           "maxOutput": "~32K",
-          "modality": "Text (reasoning)",
+          "modality": "Text",
+          "rateLimit": "2 RPM (anonymous)"
+        },
+        {
+          "id": "Qwen3.5-9B",
+          "name": "Qwen3.5-9B",
+          "context": "131K",
+          "maxOutput": "~8K",
+          "modality": "Text",
           "rateLimit": "2 RPM (anonymous)"
         },
         {
@@ -1332,9 +1060,9 @@
           "rateLimit": "2 RPM (anonymous)"
         },
         {
-          "id": "Mixtral-8x7B-Instruct-v0.1",
-          "name": "Mixtral-8x7B-Instruct-v0.1",
-          "context": "32K",
+          "id": "Mistral-Small-3.2-24B-Instruct-2506",
+          "name": "Mistral-Small-3.2-24B-Instruct",
+          "context": "128K",
           "maxOutput": "~4K",
           "modality": "Text",
           "rateLimit": "2 RPM (anonymous)"
@@ -1348,28 +1076,72 @@
           "rateLimit": "2 RPM (anonymous)"
         },
         {
-          "id": "Qwen3Guard-Gen-8B",
-          "name": "Qwen3Guard-Gen-8B",
+          "id": "Mistral-7B-Instruct-v0.3",
+          "name": "Mistral-7B-Instruct-v0.3",
           "context": "32K",
           "maxOutput": "~4K",
-          "modality": "Text (safety guard)",
+          "modality": "Text",
           "rateLimit": "2 RPM (anonymous)"
+        }
+      ]
+    },
+    {
+      "name": "SambaNova",
+      "category": "inference_provider",
+      "country": "US",
+      "flag": "🇺🇸",
+      "url": "https://cloud.sambanova.ai/apis",
+      "baseUrl": "https://api.sambanova.ai/v1",
+      "description": "Free tier, no credit card. Ultra-fast RDU inference. 20 RPM, 200K tokens/day.",
+      "footnoteRef": 8,
+      "models": [
+        {
+          "id": "DeepSeek-V3.1",
+          "name": "DeepSeek-V3.1",
+          "context": "128K",
+          "maxOutput": "~8K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
         },
         {
-          "id": "Qwen3Guard-Gen-0.6B",
-          "name": "Qwen3Guard-Gen-0.6B",
-          "context": "32K",
-          "maxOutput": "~4K",
-          "modality": "Text (safety guard)",
-          "rateLimit": "2 RPM (anonymous)"
+          "id": "DeepSeek-V3.2",
+          "name": "DeepSeek-V3.2 (Preview)",
+          "context": "128K",
+          "maxOutput": "~8K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
         },
         {
-          "id": null,
-          "name": "+ 30 more models",
-          "context": "Varies",
-          "maxOutput": "Varies",
-          "modality": "Text, Vision, Code, Image, Speech",
-          "rateLimit": "2 RPM (anonymous)"
+          "id": "Meta-Llama-3.3-70B-Instruct",
+          "name": "Meta-Llama-3.3-70B-Instruct",
+          "context": "128K",
+          "maxOutput": "~8K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
+        },
+        {
+          "id": "gpt-oss-120b",
+          "name": "gpt-oss-120b",
+          "context": "128K",
+          "maxOutput": "~8K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
+        },
+        {
+          "id": "MiniMax-M2.7",
+          "name": "MiniMax-M2.7",
+          "context": "128K",
+          "maxOutput": "~8K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
+        },
+        {
+          "id": "gemma-4-31B-it",
+          "name": "gemma-4-31B-it (Preview)",
+          "context": "128K",
+          "maxOutput": "~8K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
         }
       ]
     },
@@ -1380,7 +1152,7 @@
       "flag": "🇨🇳",
       "url": "https://cloud.siliconflow.cn/account/ak",
       "baseUrl": "https://api.siliconflow.cn/v1",
-      "description": "3 permanently free models. Free tier capped at 50 req/day; ≥10 CNY lifetime purchase raises cap to 1,000/day. 200+ paid models also available.",
+      "description": "Permanently free models, no credit card required. 200+ paid models also available.",
       "footnoteRef": null,
       "models": [
         {
@@ -1398,86 +1170,6 @@
           "maxOutput": "Configurable",
           "modality": "Text (reasoning)",
           "rateLimit": "30 RPM, 60K TPM"
-        },
-        {
-          "id": "deepseek-ai/DeepSeek-OCR",
-          "name": "deepseek-ai/DeepSeek-OCR",
-          "context": "—",
-          "maxOutput": "8K",
-          "modality": "Vision (OCR)",
-          "rateLimit": "30 RPM, 60K TPM"
-        }
-      ]
-    },
-    {
-      "name": "Aion Labs",
-      "category": "provider_api",
-      "country": "IL",
-      "flag": "🇮🇱",
-      "url": "https://www.aionlabs.ai",
-      "baseUrl": "https://api.aionlabs.ai/v1",
-      "description": "Free daily token allowance, no credit card required. Specialized for roleplay and storytelling.",
-      "footnoteRef": null,
-      "models": [
-        {
-          "id": "aion-2.0",
-          "name": "aion-2.0",
-          "context": "131K",
-          "maxOutput": "~32K",
-          "modality": "Text (roleplay)",
-          "rateLimit": "Daily token allowance"
-        },
-        {
-          "id": "aion-1.0",
-          "name": "aion-1.0",
-          "context": "131K",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "Daily token allowance"
-        },
-        {
-          "id": "aion-1.0-mini",
-          "name": "aion-1.0-mini",
-          "context": "131K",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "Daily token allowance"
-        }
-      ]
-    },
-    {
-      "name": "xAI",
-      "category": "provider_api",
-      "country": "US",
-      "flag": "🇺🇸",
-      "url": "https://console.x.ai",
-      "baseUrl": "https://api.x.ai/v1",
-      "description": "$25 sign-up credit, no credit card required. One-time only; additional $150/month available via opt-in data-sharing program (requires prior spend).",
-      "footnoteRef": 12,
-      "models": [
-        {
-          "id": "grok-4.3",
-          "name": "grok-4.3",
-          "context": "1M",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "Credit-based"
-        },
-        {
-          "id": "grok-4.1-fast",
-          "name": "grok-4.1-fast",
-          "context": "2M",
-          "maxOutput": "~32K",
-          "modality": "Text",
-          "rateLimit": "Credit-based"
-        },
-        {
-          "id": "grok-3-mini",
-          "name": "grok-3-mini",
-          "context": "131K",
-          "maxOutput": "8K",
-          "modality": "Text",
-          "rateLimit": "Credit-based"
         }
       ]
     }
@@ -1489,7 +1181,7 @@
     },
     {
       "id": 2,
-      "text": "Groq rate limits vary by model. Llama 4 Maverick is limited to 500 RPD. Most other models get 14,400 RPD ([rate limits](https://console.groq.com/docs/rate-limits))."
+      "text": "Groq rate limits were reduced in 2026. Most models now get 1,000 RPD on the free tier (down from 14,400). Llama 4 Maverick has been deprecated. See [rate limits](https://console.groq.com/docs/rate-limits)."
     },
     {
       "id": 3,
@@ -1497,7 +1189,7 @@
     },
     {
       "id": 4,
-      "text": "Free models default to 50 RPD per model. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order. Free providers may log prompts for training."
+      "text": "Free models default to 200 RPD per model. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order. Free providers may log prompts for training."
     },
     {
       "id": 5,
@@ -1509,27 +1201,11 @@
     },
     {
       "id": 7,
-      "text": "OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required — click \"Get your free token\" on the OVHcloud AI Endpoints site. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers."
+      "text": "OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers."
     },
     {
       "id": 8,
-      "text": "Free quota is signup-only with 90-day expiration and only granted in the Singapore / International region. Alibaba Cloud account requires phone/email verification but no credit card. After exhaustion, pay-as-you-go applies. Use the international endpoint `dashscope-intl.aliyuncs.com`; the China region (`dashscope.aliyuncs.com`) requires real-name verification."
-    },
-    {
-      "id": 9,
-      "text": "DeepSeek grants 5M free tokens at signup with a 30-day expiration. After expiry, pay-as-you-go applies. No credit card required at signup; prompts may be used to improve models unless explicitly opted out in account settings."
-    },
-    {
-      "id": 10,
-      "text": "Nebius grants $1 in free credits at signup, usable without a payment method. Credit card required to top up after exhaustion. Promo codes have expiration dates; the base $1 credit typically does not expire."
-    },
-    {
-      "id": 11,
-      "text": "Nscale grants $5 in free signup credits with no credit card required. Credits typically expire within 30–90 days (check console). Credit card required to top up. Pay-per-token after free credits exhausted. EU-sovereign, with data centers in Norway."
-    },
-    {
-      "id": 12,
-      "text": "xAI's $25 sign-up credit is one-time. Users who opt into the data-sharing program (prompts logged) receive an additional $150/month in credits, but the program requires $5 of prior spend before activation, so it is not a pure free tier. Several older Grok models (grok-4, grok-4-fast, grok-4-1-fast) were retired on May 15, 2026 and now redirect to grok-4.3 ([models](https://docs.x.ai/developers/models))."
+      "text": "SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible."
     }
   ],
   "glossary": [


### PR DESCRIPTION
## Summary

- **Remove 6 trial-credit providers**: AI21 Labs, Alibaba Cloud Model Studio, DeepSeek, xAI, Nebius, Nscale — none have permanent free tiers
- **Remove non-text models**: Cohere Embed/Rerank, Groq Whisper, SiliconFlow DeepSeek-OCR, ModelScope image gen
- **Add SambaNova** as new inference provider (permanent free tier, 6 models, ultra-fast RDU inference)
- **Update 13 existing providers** with new models, deprecated model removals, and corrected rate limits:
  - Google Gemini: add Gemini 3.5 Flash, 3.1 Flash-Lite; update rate limits
  - Mistral AI: add Mistral Medium 3.5 (128B)
  - Cohere: add Command A+ (218B)
  - Aion Labs: add Aion 2.5, remove sunset models
  - Groq: remove deprecated models (kimi-k2, maverick, deepseek-r1-distill), update RPD limits
  - Cerebras: reduced to 2 confirmed models
  - OpenRouter: full refresh from live API (22 free models)
  - OVHcloud: add Qwen3.5-397B, Qwen3.6-27B, gpt-oss-120b/20b, Mistral-Small-3.2
  - Cloudflare: add gpt-oss-120b, kimi-k2.7-code, glm-4.7-flash
  - Z AI: remove discontinued GLM-4.5-Flash

**Result**: 19 providers (5 Provider APIs + 14 Inference Providers), all with verified permanent free tiers.

## Test plan

- [ ] Verify `node scripts/generate-readme.js` regenerates README.md cleanly
- [ ] Spot-check base URLs respond (curl tests passed for all 19 providers)
- [ ] Review OpenRouter free model list against live API (`/api/v1/models`)
- [ ] Review OVHcloud model list against live anonymous endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)