### PR TITLE
Add Api.Airforce (unified OpenAI/Anthropic-compatible gateway, free tier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ Base URL: `https://open.bigmodel.cn/api/paas/v4`
 
 Third-party platforms that host open-weight models from various sources.
 
+### [Api.Airforce](https://api.airforce)
+
+Unified, OpenAI- & Anthropic-compatible gateway. Permanent free tier (free models, no credit card) plus pay-as-you-go from $0 for 100+ models across text, image, audio and video. OpenAI SDK-compatible; official SDKs in 8 languages.
+
+Base URL: `https://api.airforce/v1`
+
+| Model Name         | Context | Max Output | Modality | Rate Limit                                      |
+| ------------------ | ------- | ---------- | -------- | ----------------------------------------------- |
+| GLM-4.7 Flash      | 203K    | 131K       | Text     | Free tier (per-key throttle + daily token cap)  |
+| Kimi K2.6 Thinking | 262K    | 16K        | Text     | Free tier (per-key throttle + daily token cap)  |
+| DeepSeek V3.2      | 164K    | 8K         | Text     | Free tier (per-key throttle + daily token cap)  |
+| GPT-OSS 120B       | 131K    | 33K        | Text     | Free tier (per-key throttle + daily token cap)  |
+
 ### [Cerebras](https://cloud.cerebras.ai/) 🇺🇸
 
 Free tier, no credit card. Ultra-fast inference (~2,600 tok/s). 1M tokens/day cap. 8K context cap on free tier. llama3.1-8b scheduled for deprecation May 27, 2026.


### PR DESCRIPTION
Adds **Api.Airforce** under *Inference providers* — a unified, OpenAI- & Anthropic-compatible gateway with a permanent free tier (free open-weight models, no credit card) plus pay-as-you-go for 100+ models across text, image, audio and video.

- Base URL: `https://api.airforce/v1`
- OpenAI SDK-compatible; official SDKs in 8 languages
- Representative free open-weight models listed (GLM-4.7 Flash, Kimi K2.6 Thinking, DeepSeek V3.2, GPT-OSS 120B)

Placed alphabetically at the top of the Inference providers section, matching the existing OpenRouter-style aggregator entry.