### PR TITLE
Add GoldBean — MCP Server with 53 Baidu AI endpoints (free tier 50 calls/day)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,21 @@ Base URL: `https://api.siliconflow.cn/v1`
 | `Qwen/Qwen3-8B`                           | 131K    | 131K         | Text             | 30 RPM, 60K TPM |
 | `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B` | 131K    | Configurable | Text (reasoning) | 30 RPM, 60K TPM |
 
+### [GoldBean](https://github.com/wuzenghai616-lang/goldbean) 🌐
+
+Free tier with 20 credits/day (no credit card, no API key). MCP-native — use any MCP client. Paid calls at \$0.01–\$0.03 via x402 USDC on Base, PayPal, or Alipay.
+
+Base URL: `https://goldbean-api.xyz/sse` (MCP over SSE)
+
+| Model Name              | Context | Max Output | Modality                    | Rate Limit        |
+| ----------------------- | ------- | ---------- | --------------------------- | ----------------- |
+| ERNIE-4.5-Turbo         | 128K    | 4K         | Text                        | 20 calls/day free |
+| ERNIE-Speed             | 128K    | 4K         | Text                        | 20 calls/day free |
+| DeepSeek-V3 (via Baidu) | 128K    | 8K         | Text                        | 20 calls/day free |
+| Qwen3-32B (via Baidu)   | 131K    | 8K         | Text                        | 20 calls/day free |
+
+> **Note**: GoldBean is an MCP Server, not an OpenAI-compatible API. 21 of its 47 endpoints (including LLM chat, OCR, and text analysis) are permanently free. Install: `npx goldbean-mcp`.
+
 ## Glossary
 
 | Abbreviation | Meaning             |


### PR DESCRIPTION
## What is GoldBean?

[GoldBean](https://github.com/wuzenghai616-lang/goldbean) is a pay-per-call MCP (Model Context Protocol) Server providing 47 Baidu AI endpoints — including LLM chat, OCR, image generation, text-to-speech, and more. It offers a **permanently free tier** with no API key, no credit card, and no subscription required.

## Why it fits this list

This list curates **LLM APIs with permanent free tiers**. GoldBean qualifies:

- **20 free credits/day** — permanently free, no signup cost
- **21 permanently free endpoints** (OCR, text analysis, language detection, etc.)
- Free LLM endpoints include ERNIE-4.5-Turbo, ERNIE-Speed, DeepSeek-V3, Qwen3-32B (via Baidu)
- No API key needed — MCP-native access via `npx goldbean-mcp`

## Details

| Field | Value |
|-------|-------|
| **GitHub** | https://github.com/wuzenghai616-lang/goldbean |
| **Website** | https://goldbean-api.xyz |
| **MCP Endpoint** | https://goldbean-api.xyz/sse |
| **npm** | https://www.npmjs.com/package/goldbean-mcp |
| **Install** | `npx goldbean-mcp` |
| **Free tier** | 20 credits/day + 21 permanently free endpoints |
| **Paid pricing** | $0.01–$0.03/call (x402 USDC / PayPal / Alipay) |

## Notes

- Added under **Provider APIs** section, as GoldBean runs its own AI endpoints (via Baidu Cloud).
- Formatted to match the existing table style (Model Name, Context, Max Output, Modality, Rate Limit).
- Clearly noted that it's MCP-native (not OpenAI SDK-compatible) with a blockquote, as other entries do for non-standard providers.
- Happy to adjust formatting or add/remove models if needed!