### PR TITLE
Add UnoRouter to inference providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,21 @@ Base URL: `https://api.siliconflow.cn/v1`
 | `Qwen/Qwen3-8B`                           | 131K    | 131K         | Text             | 30 RPM, 60K TPM |
 | `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B` | 131K    | Configurable | Text (reasoning) | 30 RPM, 60K TPM |
 
+### [UnoRouter](https://unorouter.com/token) 🇩🇪
+
+Permanent free tier, no credit card (Discord or GitHub sign-in). 190+ models carry a `:free` suffix, roughly 1 request per minute per model per user; the cap returns HTTP 429 with a Retry-After header, so rotating between free models is the intended pattern. Output capped at 8K on free models. Open source stack ([free tier details](https://unorouter.com/en/blog/free-models-aggregated)).
+
+Base URL: `https://api.unorouter.com/v1`
+
+| Model Name                        | Context | Max Output | Modality         | Rate Limit  |
+| --------------------------------- | ------- | ---------- | ---------------- | ----------- |
+| `deepseek-v4-flash:free`          | 1M      | 8K         | Text (reasoning) | 1 RPM/model |
+| `deepseek-v4-pro:free`            | 1M      | 8K         | Text (reasoning) | 1 RPM/model |
+| `glm-5.2:free`                    | 1M      | 8K         | Text (reasoning) | 1 RPM/model |
+| `qwen3.5-397b-a17b:free`          | 262K    | 8K         | Text (reasoning) | 1 RPM/model |
+| `nemotron-3-ultra-550b-a55b:free` | 1M      | 8K         | Text             | 1 RPM/model |
+| `step-3.7-flash:free`             | 128K    | 8K         | Text             | 1 RPM/model |
+
 ## Glossary
 
 | Abbreviation | Meaning             |

--- a/data.json
+++ b/data.json
@@ -1172,6 +1172,66 @@
           "rateLimit": "30 RPM, 60K TPM"
         }
       ]
+    },
+    {
+      "name": "UnoRouter",
+      "category": "inference_provider",
+      "country": "DE",
+      "flag": "🇩🇪",
+      "url": "https://unorouter.com/token",
+      "baseUrl": "https://api.unorouter.com/v1",
+      "description": "Permanent free tier, no credit card (Discord or GitHub sign-in). 190+ models carry a `:free` suffix, roughly 1 request per minute per model per user; the cap returns HTTP 429 with a Retry-After header, so rotating between free models is the intended pattern. Output capped at 8K on free models. Open source stack ([free tier details](https://unorouter.com/en/blog/free-models-aggregated)).",
+      "footnoteRef": null,
+      "models": [
+        {
+          "id": "deepseek-v4-flash:free",
+          "name": "deepseek-v4-flash:free",
+          "context": "1M",
+          "maxOutput": "8K",
+          "modality": "Text (reasoning)",
+          "rateLimit": "1 RPM/model"
+        },
+        {
+          "id": "deepseek-v4-pro:free",
+          "name": "deepseek-v4-pro:free",
+          "context": "1M",
+          "maxOutput": "8K",
+          "modality": "Text (reasoning)",
+          "rateLimit": "1 RPM/model"
+        },
+        {
+          "id": "glm-5.2:free",
+          "name": "glm-5.2:free",
+          "context": "1M",
+          "maxOutput": "8K",
+          "modality": "Text (reasoning)",
+          "rateLimit": "1 RPM/model"
+        },
+        {
+          "id": "qwen3.5-397b-a17b:free",
+          "name": "qwen3.5-397b-a17b:free",
+          "context": "262K",
+          "maxOutput": "8K",
+          "modality": "Text (reasoning)",
+          "rateLimit": "1 RPM/model"
+        },
+        {
+          "id": "nemotron-3-ultra-550b-a55b:free",
+          "name": "nemotron-3-ultra-550b-a55b:free",
+          "context": "1M",
+          "maxOutput": "8K",
+          "modality": "Text",
+          "rateLimit": "1 RPM/model"
+        },
+        {
+          "id": "step-3.7-flash:free",
+          "name": "step-3.7-flash:free",
+          "context": "128K",
+          "maxOutput": "8K",
+          "modality": "Text",
+          "rateLimit": "1 RPM/model"
+        }
+      ]
     }
   ],
   "footnotes": [


### PR DESCRIPTION
Adds UnoRouter to the inference providers section, via data.json + regenerated README per the repo workflow.

Meets the criteria: permanent free tier (no trial credits), no credit card (Discord or GitHub sign-in), OpenAI SDK compatible REST API at https://api.unorouter.com/v1. 190+ models carry a `:free` suffix at roughly 1 request per minute per model per user; the cap returns HTTP 429 with a Retry-After header. Free tier mechanics are documented at https://unorouter.com/en/blog/free-models-aggregated and the live model list at https://unorouter.com/models. The whole stack is open source (github.com/unorouter).

Disclosure: I run UnoRouter. Entry follows the SiliconFlow shape; `node scripts/generate-readme.js` output committed unmodified.