### PR TITLE
Updated api limits and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Base URL: `https://api.groq.com/openai/v1`
 
 ### [Hugging Face](https://huggingface.co/settings/tokens) 🇺🇸
 
-100K monthly Inference Provider credits for free users. Routes to Fireworks, Together, Hyperbolic, Nebius, Novita, DeepInfra and others. Thousands of models.
+$0.10 in monthly Inference Provider credits for free users. Routes to Fireworks, Together, Hyperbolic, Nebius, Novita, DeepInfra and others. Thousands of models.
 
 Base URL: `https://router.huggingface.co/v1`
 

--- a/README.md
+++ b/README.md
@@ -121,26 +121,6 @@ Base URL: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run`
 | `@cf/deepseek-ai/deepseek-r1-distill-qwen-32b` | 32K       | Shared w/ context | Text (reasoning)               | 10K neurons/day (shared) |
 | + 42 more models                               | Varies    | Varies            | Text, Image, Audio, Embeddings | 10K neurons/day (shared) |
 
-### [GitHub Models](https://github.com/marketplace/models) 🇺🇸
-
-Free prototyping for all GitHub users. 45+ models. Per-request limits (8K in / 4K out).
-
-Base URL: `https://models.github.ai/inference`
-
-| Model Name                | Context | Max Output | Modality         | Rate Limit      |
-| ------------------------- | ------- | ---------- | ---------------- | --------------- |
-| gpt-5                     | 200K    | 32K        | Text             | 10 RPM, 50 RPD  |
-| gpt-4.1                   | 1M      | 32K        | Text             | 10 RPM, 50 RPD  |
-| gpt-4.1-mini              | 1M      | 32K        | Text             | 15 RPM, 150 RPD |
-| gpt-4o                    | 128K    | 16K        | Text + Vision    | 10 RPM, 50 RPD  |
-| o4-mini                   | 200K    | 100K       | Text (reasoning) | 10 RPM, 50 RPD  |
-| Llama-4-Scout-17B-16E     | 512K    | ~4K        | Text + Vision    | 15 RPM, 150 RPD |
-| Llama-4-Maverick-17B-128E | 256K    | ~4K        | Text + Vision    | 10 RPM, 50 RPD  |
-| Meta-Llama-3.3-70B        | 131K    | ~4K        | Text             | 15 RPM, 150 RPD |
-| DeepSeek-R1               | 64K     | 8K         | Text (reasoning) | 15 RPM, 150 RPD |
-| Mistral-Small-3.1         | 128K    | ~4K        | Text + Vision    | 15 RPM, 150 RPD |
-| + 35 more models          | Varies  | Varies     | Text / Image     | Varies by tier  |
-
 ### [Groq](https://console.groq.com/keys) 🇺🇸
 
 Free tier, no credit card. Ultra-fast LPU inference. [^2]

--- a/README.md
+++ b/README.md
@@ -56,12 +56,11 @@ Free tier unavailable in EU/UK/Switzerland. Free-tier prompts may be used by Goo
 
 Base URL: `https://generativelanguage.googleapis.com/v1beta`
 
-| Model Name            | Context | Max Output | Modality                     | Rate Limit        |
-| --------------------- | ------- | ---------- | ---------------------------- | ----------------- |
-| Gemini 3.5 Flash      | 1M      | 64K        | Text + Image + Audio + Video | 15 RPM, 1,500 RPD |
-| Gemini 3.1 Flash-Lite | 1M      | 65K        | Text + Image + Audio + Video | 30 RPM, 1,500 RPD |
-| Gemini 2.5 Flash      | 1M      | 65K        | Text + Image + Audio + Video | 15 RPM, 1,500 RPD |
-| Gemini 2.5 Pro        | 2M      | 65K        | Text + Image + Audio + Video | 5 RPM, 50 RPD     |
+| Model Name            | Context | Max Output | Modality                     | Rate Limit |
+| --------------------- | ------- | ---------- | ---------------------------- | ---------- |
+| Gemini 3.5 Flash      | 1M      | 65K        | Text + Image + Audio + Video | 20 RPD     |
+| Gemini 3.1 Flash-Lite | 1M      | 65K        | Text + Image + Audio + Video | 500 RPD    |
+| Gemma 4 31B           | 128K    | 8K         | Text                         | 14.4K RPD  |
 
 ### [Mistral AI](https://console.mistral.ai/api-keys) 🇫🇷
 


### PR DESCRIPTION
## Summary

Updatd outdated free-tier information for Google Gemini and Hugging Face Inference Providers, and remove GitHub Models ahead of its scheduled retirement.

## Changes

- Updated Google Gemini model and rate-limit information:
  - Gemini 3.5 Flash: 20 RPD
  - Gemini 3.1 Flash-Lite: 500 RPD
  - Gemma 4 31B: 14.4K RPD
- Updated Hugging Face Inference Providers' free-tier allowance from 100K monthly credits to $0.10 in monthly credits for free users.
- Removed GitHub Models because GitHub has announced that the service will be fully retired on July 30, 2026.

## Verification

The updated information was checked against the respective providers' official documentation and announcements.

## References

- [Google Gemini API documentation](https://aistudio.google.com/rate-limit?timeRange=last-hour&project)
- [Hugging Face Inference Providers pricing documentation](https://huggingface.co/docs/inference-providers/en/pricing)
- [GitHub Changelog: GitHub Models is being fully retired on July 30, 2026](https://github.blog/changelog/2026-07-01-github-models-is-being-fully-retired-on-july-30-2026/)