### PR TITLE
fix: update dead model IDs across Hugging Face, NVIDIA NIM, OVHcloud (2026-07-30)

### DIFF
--- a/data.json
+++ b/data.json
@@ -496,7 +496,7 @@
       "footnoteRef": null,
       "models": [
         {
-          "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+          "id": "meta-llama/Llama-3.1-8B-Instruct",
           "name": "Meta-Llama-3.1-8B-Instruct",
           "context": "128K",
           "maxOutput": "~4K",
@@ -504,25 +504,25 @@
           "rateLimit": "Credit-metered"
         },
         {
-          "id": "mistralai/Mistral-7B-Instruct-v0.3",
-          "name": "Mistral-7B-Instruct-v0.3",
-          "context": "32K",
+          "id": "google/gemma-3-4b-it",
+          "name": "gemma-3-4b-it",
+          "context": "131K",
           "maxOutput": "~4K",
           "modality": "Text",
           "rateLimit": "Credit-metered"
         },
         {
-          "id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-          "name": "Mixtral-8x7B-Instruct-v0.1",
-          "context": "32K",
-          "maxOutput": "~4K",
-          "modality": "Text",
-          "rateLimit": "Credit-metered"
-        },
-        {
-          "id": "microsoft/Phi-3.5-mini-instruct",
-          "name": "Phi-3.5-mini-instruct",
+          "id": "microsoft/phi-4",
+          "name": "phi-4",
           "context": "128K",
+          "maxOutput": "~4K",
+          "modality": "Text",
+          "rateLimit": "Credit-metered"
+        },
+        {
+          "id": "Qwen/Qwen2.5-Coder-7B-Instruct",
+          "name": "Qwen2.5-Coder-7B-Instruct",
+          "context": "131K",
           "maxOutput": "~4K",
           "modality": "Text",
           "rateLimit": "Credit-metered"
@@ -720,11 +720,11 @@
       "footnoteRef": null,
       "models": [
         {
-          "id": "deepseek-ai/deepseek-r1",
-          "name": "deepseek-ai/deepseek-r1",
-          "context": "128K",
-          "maxOutput": "~163K",
-          "modality": "Text (reasoning)",
+          "id": "deepseek-ai/deepseek-v4-flash",
+          "name": "deepseek-ai/deepseek-v4-flash",
+          "context": "1M",
+          "maxOutput": "~64K",
+          "modality": "Text",
           "rateLimit": "~40 RPM"
         },
         {
@@ -752,24 +752,24 @@
           "rateLimit": "~40 RPM"
         },
         {
-          "id": "meta/llama-3.1-405b-instruct",
-          "name": "meta/llama-3.1-405b-instruct",
+          "id": "meta/llama-3.3-70b-instruct",
+          "name": "meta/llama-3.3-70b-instruct",
           "context": "128K",
           "maxOutput": "4K",
           "modality": "Text",
           "rateLimit": "~40 RPM"
         },
         {
-          "id": "qwen/qwen2.5-72b-instruct",
-          "name": "qwen/qwen2.5-72b-instruct",
+          "id": "mistralai/mistral-nemotron",
+          "name": "mistralai/mistral-nemotron",
           "context": "128K",
           "maxOutput": "8K",
           "modality": "Text",
           "rateLimit": "~40 RPM"
         },
         {
-          "id": "google/gemma-4-31b",
-          "name": "google/gemma-4-31b",
+          "id": "google/gemma-4-31b-it",
+          "name": "google/gemma-4-31b-it",
           "context": "128K",
           "maxOutput": "8K",
           "modality": "Text",
@@ -1006,14 +1006,6 @@
         {
           "id": "Meta-Llama-3_3-70B-Instruct",
           "name": "Meta-Llama-3_3-70B-Instruct",
-          "context": "131K",
-          "maxOutput": "~4K",
-          "modality": "Text",
-          "rateLimit": "2 RPM (anonymous)"
-        },
-        {
-          "id": "Llama-3.1-8B-Instruct",
-          "name": "Llama-3.1-8B-Instruct",
           "context": "131K",
           "maxOutput": "~4K",
           "modality": "Text",


### PR DESCRIPTION
## Summary
9 model IDs updated across 3 providers, each confirmed via live endpoint before commit.

## Changes (verified by GET /models or live 404)
| Provider | Field | Before | After | Evidence |
|---|---|---|---|---|
| Hugging Face | id | meta-llama/Meta-Llama-3.1-8B-Instruct | meta-llama/Llama-3.1-8B-Instruct | ABSENT→PRESENT on GET /v1/models |
| Hugging Face | id | mistralai/Mistral-7B-Instruct-v0.3 | google/gemma-3-4b-it | ABSENT→PRESENT |
| Hugging Face | id | mistralai/Mixtral-8x7B-Instruct-v0.1 | microsoft/phi-4 | ABSENT→PRESENT |
| Hugging Face | id | microsoft/Phi-3.5-mini-instruct | Qwen/Qwen2.5-Coder-7B-Instruct | ABSENT→PRESENT |
| NVIDIA NIM | id | deepseek-ai/deepseek-r1 | deepseek-ai/deepseek-v4-flash | ABSENT→PRESENT on GET /v1/models |
| NVIDIA NIM | id | meta/llama-3.1-405b-instruct | meta/llama-3.3-70b-instruct | ABSENT→PRESENT |
| NVIDIA NIM | id | qwen/qwen2.5-72b-instruct | mistralai/mistral-nemotron | ABSENT→PRESENT |
| NVIDIA NIM | id | google/gemma-4-31b | google/gemma-4-31b-it | ABSENT→PRESENT (missing -it suffix) |
| OVHcloud | — | Llama-3.1-8B-Instruct | removed | HTTP 404 on 3 consecutive daily runs |

## Not touched (still present on provider endpoints)
- nvidia/llama-3.1-nemotron-ultra-253b-v1 — PRESENT, no change
- mistralai/mistral-large-2-instruct — PRESENT, no change
- minimax/minimax-m2.7 — ABSENT but no confirmed replacement found

## Inspired by PR #75
Reviewed PR #75 by @Ekouekoussawo, validated each change independently via provider /models endpoints, applied only what could be confirmed.
