### PR TITLE
Add Gonka Broker (Inference providers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ Base URL: `https://models.github.ai/inference`
 | Mistral-Small-3.1                      | 128K    | ~4K        | Text + Vision    | 15 RPM, 150 RPD |
 | + 35 more models                       | Varies  | Varies     | Text / Image     | Varies by tier  |
 
+### [Gonka Broker](https://app.gonkabroker.com/signup) 🇺🇸
+
+Permanent free tier, no credit card required. 1M+ tokens/month across all models, resets monthly. Model lineup rotates with network governance — live list at /v1/models.
+
+Base URL: `https://proxy.gonkabroker.com/v1`
+
+| Model Name               | Context | Max Output | Modality   | Rate Limit                |
+| ------------------------ | ------- | ---------- | ---------- | ------------------------- |
+| `MiniMaxAI/MiniMax-M2.7` | 204K    | 16K        | Text       | 1M+ tokens/month (shared) |
+| `moonshotai/Kimi-K2.6`   | 262K    | 8K         | Text       | 1M+ tokens/month (shared) |
+| `BAAI/bge-m3`            | 8K      | —          | Embeddings | 1M+ tokens/month (shared) |
+
 ### [Groq](https://console.groq.com/keys) 🇺🇸
 
 Free tier, no credit card. Ultra-fast LPU inference. [^2]

--- a/data.json
+++ b/data.json
@@ -546,6 +546,42 @@
       ]
     },
     {
+      "name": "Gonka Broker",
+      "category": "inference_provider",
+      "country": "US",
+      "flag": "🇺🇸",
+      "url": "https://app.gonkabroker.com/signup",
+      "baseUrl": "https://proxy.gonkabroker.com/v1",
+      "description": "Permanent free tier, no credit card required. 1M+ tokens/month across all models, resets monthly. Model lineup rotates with network governance — live list at /v1/models.",
+      "footnoteRef": null,
+      "models": [
+        {
+          "id": "MiniMaxAI/MiniMax-M2.7",
+          "name": "MiniMaxAI/MiniMax-M2.7",
+          "context": "204K",
+          "maxOutput": "16K",
+          "modality": "Text",
+          "rateLimit": "1M+ tokens/month (shared)"
+        },
+        {
+          "id": "moonshotai/Kimi-K2.6",
+          "name": "moonshotai/Kimi-K2.6",
+          "context": "262K",
+          "maxOutput": "8K",
+          "modality": "Text",
+          "rateLimit": "1M+ tokens/month (shared)"
+        },
+        {
+          "id": "BAAI/bge-m3",
+          "name": "BAAI/bge-m3",
+          "context": "8K",
+          "maxOutput": "—",
+          "modality": "Embeddings",
+          "rateLimit": "1M+ tokens/month (shared)"
+        }
+      ]
+    },
+    {
       "name": "Groq",
       "category": "inference_provider",
       "country": "US",

--- a/free-llm-apis/SKILL.md
+++ b/free-llm-apis/SKILL.md
@@ -28,7 +28,7 @@ Ask the user what matters most, then recommend accordingly:
 - See [references/provider-apis.md](references/provider-apis.md) for setup instructions.
 
 **Inference providers** -- third-party platforms hosting open-weight models:
-- GitHub Models, NVIDIA NIM, Groq, Cerebras, Cloudflare Workers AI, LLM7.io, Kluster AI, OpenRouter, Hugging Face
+- GitHub Models, Gonka Broker, NVIDIA NIM, Groq, Cerebras, Cloudflare Workers AI, LLM7.io, Kluster AI, OpenRouter, Hugging Face
 - See [references/inference-providers.md](references/inference-providers.md) for setup instructions.
 
 ## Workflow

--- a/free-llm-apis/references/inference-providers.md
+++ b/free-llm-apis/references/inference-providers.md
@@ -77,6 +77,34 @@ export NVIDIA_API_KEY="your-key-here"
 
 ---
 
+## Gonka Broker
+
+**Models:** MiniMax M2.7, Kimi K2.6, BGE-M3 (embeddings) — lineup rotates; live list at https://proxy.gonkabroker.com/v1/models
+**Limits:** 1M+ tokens/month across all models, resets monthly
+
+### Get your API key
+
+1. Go to [gonkabroker.com](https://app.gonkabroker.com/signup) and sign up with email or Google.
+2. Open the **API Keys** tab and create a key.
+3. Copy the key (starts with `gnk-prx-`, shown only once).
+
+### Usage example
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="YOUR_GONKA_BROKER_KEY",
+    base_url="https://proxy.gonkabroker.com/v1"
+)
+
+response = client.chat.completions.create(
+    model="MiniMaxAI/MiniMax-M2.7",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+print(response.choices[0].message.content)
+```
+
 ## Groq
 
 **Models:** Llama 3.3 70B, Llama 4 Scout, Kimi K2 +17 more


### PR DESCRIPTION
Adds Gonka Broker — an OpenAI-compatible gateway to open-source models
running on the decentralized Gonka GPU network.

Meets the "What counts" criteria:

- Permanent free tier: 1M+ tokens/month across all models, resets monthly (recurring tier, not trial credits). Documented at https://gonkabroker.com/free-llm-api/ and https://docs.gonkabroker.com/guides/billing-and-deposits/#free-tier.
- No credit card required to sign up.
- Real REST API for LLM inference (OpenAI-compatible `/v1/chat/completions` and `/v1/embeddings`).

The model lineup rotates with network governance; the live list is available unauthenticated at https://proxy.gonkabroker.com/v1/models.

Included per repo structure: `data.json` entry, README regenerated with `scripts/generate-readme.js` (no manual README edits), skill reference section in `free-llm-apis/references/inference-providers.md`, and the provider list in `free-llm-apis/SKILL.md`.