### PR TITLE
Add OdiRouter free LLM API

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,22 @@ Base URL: `https://integrate.api.nvidia.com/v1`
 | `deepseek-ai/deepseek-v4-pro`             | 128K    | ~64K       | Text                                   | ~40 RPM    |
 | + 85 more models                          | Varies  | Varies     | Text, Image, Video, Speech, Embeddings | ~40 RPM    |
 
+### [OdiRouter](https://odirouter.ai?utm_source=mnfst&channel=github) 🇷🇺
+
+OpenAI SDK-compatible gateway with 50 free requests/day. No credit card required.
+
+Base URL: `https://api.odirouter.ai/v1`
+
+| Model Name              | Context | Max Output | Modality                     | Rate Limit |
+| ----------------------- | ------- | ---------- | ---------------------------- | ---------- |
+| Grok 4.5 (free)         | 500K    | 500K       | Text + Image                 | 50 RPD     |
+| GPT-5.6 Terra (free)    | 1.1M    | 128K       | Text + Image                 | 50 RPD     |
+| GPT-5.6 Luna (free)     | 1.1M    | 128K       | Text + Image                 | 50 RPD     |
+| Gemini 3.5 Flash (free) | 1M      | 65.5K      | Text + Image + Audio + Video | 50 RPD     |
+| Qwen3.7-Plus (free)     | 256K    | 32.8K      | Text + Image + Video         | 50 RPD     |
+| GPT-5.4 mini (free)     | 1.1M    | 131.1K     | Text + Image                 | 50 RPD     |
+| + 14 more free models   | Varies  | Varies     | Text / Image / Audio / Video | 50 RPD     |
+
 ### [Ollama Cloud](https://ollama.com/settings/keys) 🇺🇸
 
 Free tier with qualitative usage limits. 400+ models from Ollama library. Not OpenAI SDK-compatible; uses [Ollama API](https://docs.ollama.com/cloud). [^3]

--- a/data.json
+++ b/data.json
@@ -994,6 +994,74 @@
       ]
     },
     {
+      "name": "OdiRouter",
+      "category": "inference_provider",
+      "country": "RU",
+      "flag": "🇷🇺",
+      "url": "https://odirouter.ai?utm_source=mnfst&channel=github",
+      "baseUrl": "https://api.odirouter.ai/v1",
+      "description": "OpenAI SDK-compatible gateway with 50 free requests/day. No credit card required.",
+      "footnoteRef": null,
+      "models": [
+        {
+          "id": "free-grok-4.5",
+          "name": "Grok 4.5 (free)",
+          "context": "500K",
+          "maxOutput": "500K",
+          "modality": "Text + Image",
+          "rateLimit": "50 RPD"
+        },
+        {
+          "id": "free-gpt-5.6-terra",
+          "name": "GPT-5.6 Terra (free)",
+          "context": "1.1M",
+          "maxOutput": "128K",
+          "modality": "Text + Image",
+          "rateLimit": "50 RPD"
+        },
+        {
+          "id": "free-gpt-5.6-luna",
+          "name": "GPT-5.6 Luna (free)",
+          "context": "1.1M",
+          "maxOutput": "128K",
+          "modality": "Text + Image",
+          "rateLimit": "50 RPD"
+        },
+        {
+          "id": "free-gemini-3.5-flash",
+          "name": "Gemini 3.5 Flash (free)",
+          "context": "1M",
+          "maxOutput": "65.5K",
+          "modality": "Text + Image + Audio + Video",
+          "rateLimit": "50 RPD"
+        },
+        {
+          "id": "free-qwen3.7-plus",
+          "name": "Qwen3.7-Plus (free)",
+          "context": "256K",
+          "maxOutput": "32.8K",
+          "modality": "Text + Image + Video",
+          "rateLimit": "50 RPD"
+        },
+        {
+          "id": "free-gpt-5.4-mini",
+          "name": "GPT-5.4 mini (free)",
+          "context": "1.1M",
+          "maxOutput": "131.1K",
+          "modality": "Text + Image",
+          "rateLimit": "50 RPD"
+        },
+        {
+          "id": null,
+          "name": "+ 14 more free models",
+          "context": "Varies",
+          "maxOutput": "Varies",
+          "modality": "Text / Image / Audio / Video",
+          "rateLimit": "50 RPD"
+        }
+      ]
+    },
+    {
       "name": "Ollama Cloud",
       "category": "inference_provider",
       "country": "US",


### PR DESCRIPTION
## Summary

Adds OdiRouter as an OpenAI SDK-compatible inference provider with selected free LLM models.

## Verification

- Website: https://odirouter.ai?utm_source=mnfst&channel=github
- Free model catalog: https://odirouter.ai/models?category=Free&utm_source=mnfst&channel=github
- API key page: https://odirouter.ai/dashboard/api-keys
- API documentation: https://odirouter.ai/docs/get-started/introduction
- Base URL: https://api.odirouter.ai/v1
- Example model: `free-grok-4.5`
- Free tier: 50 requests/day
- No credit card required for the free tier
