### PR TITLE
Nightly refresh 2026-08-19: remove GitHub Models and Cerebras, verify Kilo Code pool, update Gemini and SiliconFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Base URL: `https://api.llm7.io/v1`
 | Model Name                         | Context | Max Output | Modality         | Rate Limit              |
 | ---------------------------------- | ------- | ---------- | ---------------- | ----------------------- |
 | `gpt-oss:20b`                      | —       | —          | Text (reasoning) | 30 RPM (120 with token) |
-| + ~60 more models (token required) | Varies  | Varies     | Text             | 30 RPM (120 with token) |
+| + ~40 more models (token required) | Varies  | Varies     | Text             | 30 RPM (120 with token) |
 
 ### [ModelScope](https://modelscope.cn/my/myaccesstoken) 🇨🇳
 
@@ -355,4 +355,4 @@ Know a free tier that's missing? [Open a PR](contributing.md). Include the provi
 [^7]: OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers.
 [^8]: SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible.
 [^9]: SiliconFlow requires real-name identity verification to use free models (effective May 15, 2026, per the [release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Verification supports mainland-Chinese documents; international users must contact support.
-[^10]: LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable. Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title.
+[^10]: LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title.

--- a/README.md
+++ b/README.md
@@ -180,11 +180,12 @@ Base URL: `https://api.kilo.ai/api/gateway`
 | `stepfun/step-3.7-flash:free`                        | 262K    | 262K       | Text             | ~200 req/hr |
 | `nvidia/nemotron-3-super-120b-a12b:free`             | 262K    | 262K       | Text             | ~200 req/hr |
 | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | 256K    | 65K        | Text (reasoning) | ~200 req/hr |
-| `inclusionai/ling-3.0-flash:free`                    | 262K    | 32K        | Text             | ~200 req/hr |
 | `poolside/laguna-s-2.1:free`                         | 262K    | 32K        | Text (code)      | ~200 req/hr |
 | `poolside/laguna-xs-2.1:free`                        | 262K    | 32K        | Text (code)      | ~200 req/hr |
 | `cohere/north-mini-code:free`                        | 256K    | 64K        | Text (code)      | ~200 req/hr |
 | `openrouter/free`                                    | Varies  | Varies     | Text             | ~200 req/hr |
+| `tencent/hy3:free`                                   | —       | —          | Text             | ~200 req/hr |
+| `nvidia/nemotron-3.5-lightning:free`                 | —       | —          | Text             | ~200 req/hr |
 
 ### [LLM7.io](https://token.llm7.io) 🇬🇧
 
@@ -296,18 +297,13 @@ Base URL: `https://oai.endpoints.kepler.ai.cloud.ovh.net/v1`
 
 ### [SambaNova](https://cloud.sambanova.ai/apis) 🇺🇸
 
-Free tier, no credit card. Ultra-fast RDU inference. 20 RPM, 200K tokens/day. [^8]
+Free tier reduced to select models, no credit card for those. Ultra-fast RDU inference. A payment method is required for all other models. [^11]
 
 Base URL: `https://api.sambanova.ai/v1`
 
-| Model Name                  | Context | Max Output | Modality             | Rate Limit               |
-| --------------------------- | ------- | ---------- | -------------------- | ------------------------ |
-| DeepSeek-V3.1               | 128K    | ~8K        | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| DeepSeek-V3.2 (Preview)     | 128K    | ~8K        | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| Meta-Llama-3.3-70B-Instruct | 128K    | ~3K        | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| gpt-oss-120b                | 128K    | ~128K      | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| MiniMax-M2.7                | 128K    | ~192K      | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| gemma-4-31B-it (Preview)    | 128K    | ~128K      | Text + Image + Video | 20 RPM, 20 RPD, 200K TPD |
+| Model Name   | Context | Max Output | Modality | Rate Limit               |
+| ------------ | ------- | ---------- | -------- | ------------------------ |
+| MiniMax-M2.7 | 128K    | ~192K      | Text     | 20 RPM, 20 RPD, 200K TPD |
 
 ### [SiliconFlow](https://cloud.siliconflow.cn/account/ak) 🇨🇳
 
@@ -338,9 +334,9 @@ Know a free tier that's missing? [Open a PR](contributing.md). Include the provi
 [^2]: Groq rate limits were reduced in 2026. Most models now get 1,000 RPD on the free tier (down from 14,400). Llama 4 Maverick has been deprecated. See [rate limits](https://console.groq.com/docs/rate-limits).
 [^3]: Ollama Cloud measures usage by GPU time, not tokens or requests. Free tier described as "light usage" with session limits resetting every 5 hours and weekly limits every 7 days. Pro (50x more) and Max (250x more) plans available. Not OpenAI SDK-compatible; uses the Ollama API.
 [^4]: Free models default to 50 RPD per model. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order. Free providers may log prompts for training.
-[^5]: Kilo Code free model list changes frequently. nvidia/nemotron-3-super-120b-a12b:free is for trial use only — prompts are logged by NVIDIA. Auto-router `kilo-auto/free` dynamically picks from the current free pool.
+[^5]: Kilo Code's free pool changes frequently, and the /api/gateway/models catalog can lag what is actually served: probe results on 2026-08-19 confirmed models absent from the catalog still answering. All listed rows were verified with live requests on that date. The kilo-auto/free router picks a model from the free pool.
 [^6]: API-Inference is free for registered users. Current published limits are 2,000 requests/day per user (total across models), with per-model daily quotas dynamically adjusted and capped at 500; concurrency is also dynamically rate-limited. Requires Alibaba Cloud account binding and real-name verification ([limits](https://modelscope.cn/docs/model-service/API-Inference/limits), [intro](https://modelscope.cn/docs/model-service/API-Inference/intro)).
 [^7]: OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers.
-[^8]: SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible.
 [^9]: SiliconFlow requires real-name identity verification to use free models (effective May 15, 2026, per the [release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Verification supports mainland-Chinese documents; international users must contact support.
 [^10]: LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title.
+[^11]: SambaNova now requires a payment method for most models: live requests on 2026-08-19 returned PAYMENT_METHOD_REQUIRED (HTTP 402) for DeepSeek-V3.1, DeepSeek-V3.2, Meta-Llama-3.3-70B-Instruct, gpt-oss-120b, and gemma-4-31B-it, while MiniMax-M2.7 still served free without a payment method. The [rate limits page](https://docs.sambanova.ai/docs/en/models/rate-limits) still describes a broader free tier; live behavior takes precedence here.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Base URL: `https://api.cohere.com/v2`
 
 ### [Google Gemini](https://aistudio.google.com/app/apikey) 🇺🇸
 
-Free tier unavailable in EU/UK/Switzerland. Free-tier prompts may be used by Google to improve products. [^1]
+Free tier, no credit card. Free-tier prompts may be used by Google to improve products. [^1]
 
 Base URL: `https://generativelanguage.googleapis.com/v1beta`
 
@@ -149,26 +149,6 @@ Base URL: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run`
 | `@cf/deepseek-ai/deepseek-r1-distill-qwen-32b` | 32K       | Shared w/ context | Text (reasoning)               | 10K neurons/day (shared) |
 | + 42 more models                               | Varies    | Varies            | Text, Image, Audio, Embeddings | 10K neurons/day (shared) |
 
-### [GitHub Models](https://github.com/marketplace/models) 🇺🇸
-
-Free prototyping for all GitHub users. 45+ models. Per-request limits (8K in / 4K out).
-
-Base URL: `https://models.github.ai/inference`
-
-| Model Name                             | Context | Max Output | Modality         | Rate Limit      |
-| -------------------------------------- | ------- | ---------- | ---------------- | --------------- |
-| gpt-5                                  | 200K    | 32K        | Text             | 10 RPM, 50 RPD  |
-| gpt-4.1                                | 1M      | 32K        | Text             | 10 RPM, 50 RPD  |
-| gpt-4.1-mini                           | 1M      | 32K        | Text             | 15 RPM, 150 RPD |
-| gpt-4o                                 | 128K    | 16K        | Text + Vision    | 10 RPM, 50 RPD  |
-| o4-mini                                | 200K    | 100K       | Text (reasoning) | 10 RPM, 50 RPD  |
-| Llama-4-Scout-17B-16E-Instruct         | 512K    | ~4K        | Text + Vision    | 15 RPM, 150 RPD |
-| Llama-4-Maverick-17B-128E-Instruct-FP8 | 256K    | ~4K        | Text + Vision    | 10 RPM, 50 RPD  |
-| Llama-3.3-70B-Instruct                 | 131K    | ~4K        | Text             | 15 RPM, 150 RPD |
-| DeepSeek-R1                            | 64K     | 8K         | Text (reasoning) | 15 RPM, 150 RPD |
-| Mistral-Small-3.1                      | 128K    | ~4K        | Text + Vision    | 15 RPM, 150 RPD |
-| + 35 more models                       | Varies  | Varies     | Text / Image     | Varies by tier  |
-
 ### [Groq](https://console.groq.com/keys) 🇺🇸
 
 Free tier, no credit card. Ultra-fast LPU inference. [^2]
@@ -220,19 +200,14 @@ Base URL: `https://api.kilo.ai/api/gateway`
 
 ### [LLM7.io](https://token.llm7.io) 🇬🇧
 
-Zero-friction API gateway. No registration needed for basic access. 30+ models. GDPR-compliant.
+API gateway with a free tier. Anonymous access is now limited to select models; a free token from token.llm7.io unlocks the rest. [^10]
 
 Base URL: `https://api.llm7.io/v1`
 
-| Model Name            | Context | Max Output | Modality         | Rate Limit              |
-| --------------------- | ------- | ---------- | ---------------- | ----------------------- |
-| deepseek-r1-0528      | —       | —          | Text (reasoning) | 30 RPM (120 with token) |
-| deepseek-v3-0324      | —       | —          | Text             | 30 RPM (120 with token) |
-| gemini-2.5-flash-lite | —       | —          | Text + Vision    | 30 RPM (120 with token) |
-| gpt-4o-mini           | —       | —          | Text + Vision    | 30 RPM (120 with token) |
-| mistral-small-3.1-24b | 32K     | —          | Text             | 30 RPM (120 with token) |
-| qwen2.5-coder-32b     | —       | —          | Text (code)      | 30 RPM (120 with token) |
-| + ~24 more models     | Varies  | Varies     | Text             | 30 RPM (120 with token) |
+| Model Name                         | Context | Max Output | Modality         | Rate Limit              |
+| ---------------------------------- | ------- | ---------- | ---------------- | ----------------------- |
+| `gpt-oss:20b`                      | —       | —          | Text (reasoning) | 30 RPM (120 with token) |
+| + ~60 more models (token required) | Varies  | Varies     | Text             | 30 RPM (120 with token) |
 
 ### [ModelScope](https://modelscope.cn/my/myaccesstoken) 🇨🇳
 
@@ -348,7 +323,7 @@ Base URL: `https://api.sambanova.ai/v1`
 
 ### [SiliconFlow](https://cloud.siliconflow.cn/account/ak) 🇨🇳
 
-Permanently free models, no credit card required. 200+ paid models also available.
+Permanently free models, no credit card required. Identity verification required. 200+ paid models also available. [^9]
 
 Base URL: `https://api.siliconflow.cn/v1`
 
@@ -371,7 +346,7 @@ Base URL: `https://api.siliconflow.cn/v1`
 
 Know a free tier that's missing? [Open a PR](contributing.md). Include the provider, endpoint, rate limits (link to their docs), and a few notable models. Trial credits and time-limited promos don't count.
 
-[^1]: Free tier not available in the EU, UK, or Switzerland ([available regions](https://ai.google.dev/gemini-api/docs/available-regions)).
+[^1]: The Gemini API free tier is now available in the EU, UK, and Switzerland; the [available regions](https://ai.google.dev/gemini-api/docs/available-regions) page lists these regions. Google no longer publishes per-model free-tier rate limits; check your quotas in [AI Studio](https://aistudio.google.com/). Free-tier prompts may be used by Google to improve products.
 [^2]: Groq rate limits were reduced in 2026. Most models now get 1,000 RPD on the free tier (down from 14,400). Llama 4 Maverick has been deprecated. See [rate limits](https://console.groq.com/docs/rate-limits).
 [^3]: Ollama Cloud measures usage by GPU time, not tokens or requests. Free tier described as "light usage" with session limits resetting every 5 hours and weekly limits every 7 days. Pro (50x more) and Max (250x more) plans available. Not OpenAI SDK-compatible; uses the Ollama API.
 [^4]: Free models default to 50 RPD per model. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order. Free providers may log prompts for training.
@@ -379,3 +354,5 @@ Know a free tier that's missing? [Open a PR](contributing.md). Include the provi
 [^6]: API-Inference is free for registered users. Current published limits are 2,000 requests/day per user (total across models), with per-model daily quotas dynamically adjusted and capped at 500; concurrency is also dynamically rate-limited. Requires Alibaba Cloud account binding and real-name verification ([limits](https://modelscope.cn/docs/model-service/API-Inference/limits), [intro](https://modelscope.cn/docs/model-service/API-Inference/intro)).
 [^7]: OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers.
 [^8]: SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible.
+[^9]: SiliconFlow requires real-name identity verification to use free models (effective May 15, 2026, per the [release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Verification supports mainland-Chinese documents; international users must contact support.
+[^10]: LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable. Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title.

--- a/README.md
+++ b/README.md
@@ -297,13 +297,18 @@ Base URL: `https://oai.endpoints.kepler.ai.cloud.ovh.net/v1`
 
 ### [SambaNova](https://cloud.sambanova.ai/apis) 🇺🇸
 
-Free tier reduced to select models, no credit card for those. Ultra-fast RDU inference. A payment method is required for all other models. [^11]
+Free tier, no credit card. Ultra-fast RDU inference. 20 RPM, 200K tokens/day. [^8]
 
 Base URL: `https://api.sambanova.ai/v1`
 
-| Model Name   | Context | Max Output | Modality | Rate Limit               |
-| ------------ | ------- | ---------- | -------- | ------------------------ |
-| MiniMax-M2.7 | 128K    | ~192K      | Text     | 20 RPM, 20 RPD, 200K TPD |
+| Model Name                  | Context | Max Output | Modality             | Rate Limit               |
+| --------------------------- | ------- | ---------- | -------------------- | ------------------------ |
+| DeepSeek-V3.1               | 128K    | ~8K        | Text                 | 20 RPM, 20 RPD, 200K TPD |
+| DeepSeek-V3.2 (Preview)     | 128K    | ~8K        | Text                 | 20 RPM, 20 RPD, 200K TPD |
+| Meta-Llama-3.3-70B-Instruct | 128K    | ~3K        | Text                 | 20 RPM, 20 RPD, 200K TPD |
+| gpt-oss-120b                | 128K    | ~128K      | Text                 | 20 RPM, 20 RPD, 200K TPD |
+| MiniMax-M2.7                | 128K    | ~192K      | Text                 | 20 RPM, 20 RPD, 200K TPD |
+| gemma-4-31B-it (Preview)    | 128K    | ~128K      | Text + Image + Video | 20 RPM, 20 RPD, 200K TPD |
 
 ### [SiliconFlow](https://cloud.siliconflow.cn/account/ak) 🇨🇳
 
@@ -334,9 +339,9 @@ Know a free tier that's missing? [Open a PR](contributing.md). Include the provi
 [^2]: Groq rate limits were reduced in 2026. Most models now get 1,000 RPD on the free tier (down from 14,400). Llama 4 Maverick has been deprecated. See [rate limits](https://console.groq.com/docs/rate-limits).
 [^3]: Ollama Cloud measures usage by GPU time, not tokens or requests. Free tier described as "light usage" with session limits resetting every 5 hours and weekly limits every 7 days. Pro (50x more) and Max (250x more) plans available. Not OpenAI SDK-compatible; uses the Ollama API.
 [^4]: Free models default to 50 RPD per model. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order. Free providers may log prompts for training.
-[^5]: Kilo Code's free pool changes frequently, and the /api/gateway/models catalog can lag what is actually served: probe results on 2026-08-19 confirmed models absent from the catalog still answering. All listed rows were verified with live requests on that date. The kilo-auto/free router picks a model from the free pool.
+[^5]: Kilo Code's free pool changes frequently, and the /api/gateway/models catalog can lag what is actually served: probe results on 2026-08-19 confirmed models absent from the catalog still answering. All listed rows were verified with live requests on that date. The kilo-auto/free router picks a model from the free pool, and Kilo's docs warn it "may route your requests to providers that log prompts and outputs".
 [^6]: API-Inference is free for registered users. Current published limits are 2,000 requests/day per user (total across models), with per-model daily quotas dynamically adjusted and capped at 500; concurrency is also dynamically rate-limited. Requires Alibaba Cloud account binding and real-name verification ([limits](https://modelscope.cn/docs/model-service/API-Inference/limits), [intro](https://modelscope.cn/docs/model-service/API-Inference/intro)).
 [^7]: OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers.
+[^8]: SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible.
 [^9]: SiliconFlow requires real-name identity verification to use free models (effective May 15, 2026, per the [release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Verification supports mainland-Chinese documents; international users must contact support.
 [^10]: LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title.
-[^11]: SambaNova now requires a payment method for most models: live requests on 2026-08-19 returned PAYMENT_METHOD_REQUIRED (HTTP 402) for DeepSeek-V3.1, DeepSeek-V3.2, Meta-Llama-3.3-70B-Instruct, gpt-oss-120b, and gemma-4-31B-it, while MiniMax-M2.7 still served free without a payment method. The [rate limits page](https://docs.sambanova.ai/docs/en/models/rate-limits) still describes a broader free tier; live behavior takes precedence here.

--- a/README.md
+++ b/README.md
@@ -119,18 +119,6 @@ Base URL: `https://open.bigmodel.cn/api/paas/v4`
 
 Third-party platforms that host open-weight models from various sources.
 
-### [Cerebras](https://cloud.cerebras.ai/) 🇺🇸
-
-Free tier with payment method required. Ultra-fast inference. 1M tokens/day cap. 64K context on free tier.
-
-Base URL: `https://api.cerebras.ai/v1`
-
-| Model Name                        | Context            | Max Output              | Modality     | Rate Limit              |
-| --------------------------------- | ------------------ | ----------------------- | ------------ | ----------------------- |
-| gpt-oss-120b                      | 131K (65K on free) | 32K (free) / 40K (paid) | Text         | 5 RPM, 30K TPM, 1M TPD  |
-| zai-glm-4.7 (deprecated Aug 2026) | 131K (64K on free) | 40K                     | Text         | 5 RPM, 30K TPM, 1M TPD  |
-| gemma-4-31b                       | 131K (65K on free) | 32K (free) / 40K (paid) | Text + Image | 15 RPM, 30K TPM, 1M TPD |
-
 ### [Cloudflare Workers AI](https://dash.cloudflare.com/profile/api-tokens) 🇺🇸
 
 10,000 Neurons/day free. 50+ models available on free tier.

--- a/contributing.md
+++ b/contributing.md
@@ -2,14 +2,20 @@
 
 Thanks for wanting to add to this list!
 
+## How the repo works
+
+`README.md` is generated automatically from `data.json` by CI. Do not edit `README.md` directly; pull requests that only change `README.md` will be asked to move the change to `data.json`.
+
 ## Adding a provider
 
-Open a pull request that adds a new line to the appropriate section in `readme.md`. Your entry should include:
+Open a pull request that adds an entry to `data.json`. Your entry should include:
 
-- Provider name, linked to their API key or signup page.
-- Country flag for where they're headquartered.
-- A short dash-separated description listing top models, rate limits (RPM/RPD), and any notable restrictions.
-- A link to the official docs that confirm the free tier and its limits.
+- Provider name and a link to their API key or signup page (`name`, `url`).
+- Country flag for where they're headquartered (`country`, `flag`).
+- The base URL of the API (`baseUrl`).
+- A short factual description stating the free tier and whether a credit card is required (`description`).
+- A models array with model id, name, context, max output, modality, and rate limit for each notable model.
+- A link in the PR description to the official docs that confirm the free tier and its limits.
 
 ## What counts
 
@@ -25,10 +31,4 @@ Open a pull request that adds a new line to the appropriate section in `readme.m
 
 ## Format
 
-Follow the existing style:
-
-```
-- [Provider Name](https://link-to-api-key-page) FLAG - Model A, Model B, Model C +N more. X RPM, Y RPD.
-```
-
-Keep descriptions on a single line. End with a period.
+Follow the structure of the existing entries in `data.json`: same fields, same notation for sizes (`128K`, `1M`, `~32K`) and rate limits (`30 RPM, 14,400 RPD`), conditions in a numbered footnote.

--- a/data.json
+++ b/data.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-07-30",
+  "lastUpdated": "2026-08-19",
   "providers": [
     {
       "name": "Aion Labs",
@@ -160,7 +160,7 @@
       "flag": "🇺🇸",
       "url": "https://aistudio.google.com/app/apikey",
       "baseUrl": "https://generativelanguage.googleapis.com/v1beta",
-      "description": "Free tier unavailable in EU/UK/Switzerland. Free-tier prompts may be used by Google to improve products.",
+      "description": "Free tier, no credit card. Free-tier prompts may be used by Google to improve products.",
       "footnoteRef": 1,
       "models": [
         {
@@ -446,106 +446,6 @@
       ]
     },
     {
-      "name": "GitHub Models",
-      "category": "inference_provider",
-      "country": "US",
-      "flag": "🇺🇸",
-      "url": "https://github.com/marketplace/models",
-      "baseUrl": "https://models.github.ai/inference",
-      "description": "Free prototyping for all GitHub users. 45+ models. Per-request limits (8K in / 4K out).",
-      "footnoteRef": null,
-      "models": [
-        {
-          "id": "openai/gpt-5",
-          "name": "gpt-5",
-          "context": "200K",
-          "maxOutput": "32K",
-          "modality": "Text",
-          "rateLimit": "10 RPM, 50 RPD"
-        },
-        {
-          "id": "openai/gpt-4.1",
-          "name": "gpt-4.1",
-          "context": "1M",
-          "maxOutput": "32K",
-          "modality": "Text",
-          "rateLimit": "10 RPM, 50 RPD"
-        },
-        {
-          "id": "openai/gpt-4.1-mini",
-          "name": "gpt-4.1-mini",
-          "context": "1M",
-          "maxOutput": "32K",
-          "modality": "Text",
-          "rateLimit": "15 RPM, 150 RPD"
-        },
-        {
-          "id": "openai/gpt-4o",
-          "name": "gpt-4o",
-          "context": "128K",
-          "maxOutput": "16K",
-          "modality": "Text + Vision",
-          "rateLimit": "10 RPM, 50 RPD"
-        },
-        {
-          "id": "openai/o4-mini",
-          "name": "o4-mini",
-          "context": "200K",
-          "maxOutput": "100K",
-          "modality": "Text (reasoning)",
-          "rateLimit": "10 RPM, 50 RPD"
-        },
-        {
-          "id": "meta/Llama-4-Scout-17B-16E-Instruct",
-          "name": "Llama-4-Scout-17B-16E-Instruct",
-          "context": "512K",
-          "maxOutput": "~4K",
-          "modality": "Text + Vision",
-          "rateLimit": "15 RPM, 150 RPD"
-        },
-        {
-          "id": "meta/Llama-4-Maverick-17B-128E-Instruct-FP8",
-          "name": "Llama-4-Maverick-17B-128E-Instruct-FP8",
-          "context": "256K",
-          "maxOutput": "~4K",
-          "modality": "Text + Vision",
-          "rateLimit": "10 RPM, 50 RPD"
-        },
-        {
-          "id": "meta/Llama-3.3-70B-Instruct",
-          "name": "Llama-3.3-70B-Instruct",
-          "context": "131K",
-          "maxOutput": "~4K",
-          "modality": "Text",
-          "rateLimit": "15 RPM, 150 RPD"
-        },
-        {
-          "id": "deepseek/DeepSeek-R1",
-          "name": "DeepSeek-R1",
-          "context": "64K",
-          "maxOutput": "8K",
-          "modality": "Text (reasoning)",
-          "rateLimit": "15 RPM, 150 RPD"
-        },
-        {
-          "id": "mistral-small-2503",
-          "name": "Mistral-Small-3.1",
-          "context": "128K",
-          "maxOutput": "~4K",
-          "modality": "Text + Vision",
-          "rateLimit": "15 RPM, 150 RPD"
-        },
-        {
-          "id": null,
-          "name": "+ 35 more models",
-          "context": "Varies",
-          "maxOutput": "Varies",
-          "modality": "Text / Image",
-          "rateLimit": "Varies by tier"
-        }
-      ]
-    },
-    {
       "name": "Groq",
       "category": "inference_provider",
       "country": "US",
@@ -764,60 +664,20 @@
       "flag": "🇬🇧",
       "url": "https://token.llm7.io",
       "baseUrl": "https://api.llm7.io/v1",
-      "description": "Zero-friction API gateway. No registration needed for basic access. 30+ models. GDPR-compliant.",
-      "footnoteRef": null,
+      "description": "API gateway with a free tier. Anonymous access is now limited to select models; a free token from token.llm7.io unlocks the rest.",
+      "footnoteRef": 10,
       "models": [
         {
-          "id": "deepseek-r1-0528",
-          "name": "deepseek-r1-0528",
+          "id": "gpt-oss:20b",
+          "name": "gpt-oss:20b",
           "context": "—",
           "maxOutput": "—",
           "modality": "Text (reasoning)",
           "rateLimit": "30 RPM (120 with token)"
         },
         {
-          "id": "deepseek-v3-0324",
-          "name": "deepseek-v3-0324",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Text",
-          "rateLimit": "30 RPM (120 with token)"
-        },
-        {
-          "id": "gemini-2.5-flash-lite",
-          "name": "gemini-2.5-flash-lite",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Text + Vision",
-          "rateLimit": "30 RPM (120 with token)"
-        },
-        {
-          "id": "gpt-4o-mini",
-          "name": "gpt-4o-mini",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Text + Vision",
-          "rateLimit": "30 RPM (120 with token)"
-        },
-        {
-          "id": "mistral-small-3.1-24b",
-          "name": "mistral-small-3.1-24b",
-          "context": "32K",
-          "maxOutput": "—",
-          "modality": "Text",
-          "rateLimit": "30 RPM (120 with token)"
-        },
-        {
-          "id": "qwen2.5-coder-32b",
-          "name": "qwen2.5-coder-32b",
-          "context": "—",
-          "maxOutput": "—",
-          "modality": "Text (code)",
-          "rateLimit": "30 RPM (120 with token)"
-        },
-        {
           "id": null,
-          "name": "+ ~24 more models",
+          "name": "+ ~60 more models (token required)",
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text",
@@ -1368,8 +1228,8 @@
       "flag": "🇨🇳",
       "url": "https://cloud.siliconflow.cn/account/ak",
       "baseUrl": "https://api.siliconflow.cn/v1",
-      "description": "Permanently free models, no credit card required. 200+ paid models also available.",
-      "footnoteRef": null,
+      "description": "Permanently free models, no credit card required. Identity verification required. 200+ paid models also available.",
+      "footnoteRef": 9,
       "models": [
         {
           "id": "Qwen/Qwen3-8B",
@@ -1393,7 +1253,7 @@
   "footnotes": [
     {
       "id": 1,
-      "text": "Free tier not available in the EU, UK, or Switzerland ([available regions](https://ai.google.dev/gemini-api/docs/available-regions))."
+      "text": "The Gemini API free tier is now available in the EU, UK, and Switzerland; the [available regions](https://ai.google.dev/gemini-api/docs/available-regions) page lists these regions. Google no longer publishes per-model free-tier rate limits; check your quotas in [AI Studio](https://aistudio.google.com/). Free-tier prompts may be used by Google to improve products."
     },
     {
       "id": 2,
@@ -1422,6 +1282,14 @@
     {
       "id": 8,
       "text": "SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible."
+    },
+    {
+      "id": 9,
+      "text": "SiliconFlow requires real-name identity verification to use free models (effective May 15, 2026, per the [release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Verification supports mainland-Chinese documents; international users must contact support."
+    },
+    {
+      "id": 10,
+      "text": "LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable. Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title."
     }
   ],
   "glossary": [

--- a/data.json
+++ b/data.json
@@ -326,42 +326,6 @@
       ]
     },
     {
-      "name": "Cerebras",
-      "category": "inference_provider",
-      "country": "US",
-      "flag": "🇺🇸",
-      "url": "https://cloud.cerebras.ai/",
-      "baseUrl": "https://api.cerebras.ai/v1",
-      "description": "Free tier with payment method required. Ultra-fast inference. 1M tokens/day cap. 64K context on free tier.",
-      "footnoteRef": null,
-      "models": [
-        {
-          "id": "gpt-oss-120b",
-          "name": "gpt-oss-120b",
-          "context": "131K (65K on free)",
-          "maxOutput": "32K (free) / 40K (paid)",
-          "modality": "Text",
-          "rateLimit": "5 RPM, 30K TPM, 1M TPD"
-        },
-        {
-          "id": "zai-glm-4.7",
-          "name": "zai-glm-4.7 (deprecated Aug 2026)",
-          "context": "131K (64K on free)",
-          "maxOutput": "40K",
-          "modality": "Text",
-          "rateLimit": "5 RPM, 30K TPM, 1M TPD"
-        },
-        {
-          "id": "gemma-4-31b",
-          "name": "gemma-4-31b",
-          "context": "131K (65K on free)",
-          "maxOutput": "32K (free) / 40K (paid)",
-          "modality": "Text + Image",
-          "rateLimit": "15 RPM, 30K TPM, 1M TPD"
-        }
-      ]
-    },
-    {
       "name": "Cloudflare Workers AI",
       "category": "inference_provider",
       "country": "US",

--- a/data.json
+++ b/data.json
@@ -580,14 +580,6 @@
           "rateLimit": "~200 req/hr"
         },
         {
-          "id": "inclusionai/ling-3.0-flash:free",
-          "name": "inclusionai/ling-3.0-flash:free",
-          "context": "262K",
-          "maxOutput": "32K",
-          "modality": "Text",
-          "rateLimit": "~200 req/hr"
-        },
-        {
           "id": "poolside/laguna-s-2.1:free",
           "name": "poolside/laguna-s-2.1:free",
           "context": "262K",
@@ -616,6 +608,22 @@
           "name": "openrouter/free",
           "context": "Varies",
           "maxOutput": "Varies",
+          "modality": "Text",
+          "rateLimit": "~200 req/hr"
+        },
+        {
+          "id": "tencent/hy3:free",
+          "name": "tencent/hy3:free",
+          "context": "—",
+          "maxOutput": "—",
+          "modality": "Text",
+          "rateLimit": "~200 req/hr"
+        },
+        {
+          "id": "nvidia/nemotron-3.5-lightning:free",
+          "name": "nvidia/nemotron-3.5-lightning:free",
+          "context": "—",
+          "maxOutput": "—",
           "modality": "Text",
           "rateLimit": "~200 req/hr"
         }
@@ -1132,55 +1140,15 @@
       "flag": "🇺🇸",
       "url": "https://cloud.sambanova.ai/apis",
       "baseUrl": "https://api.sambanova.ai/v1",
-      "description": "Free tier, no credit card. Ultra-fast RDU inference. 20 RPM, 200K tokens/day.",
-      "footnoteRef": 8,
+      "description": "Free tier reduced to select models, no credit card for those. Ultra-fast RDU inference. A payment method is required for all other models.",
+      "footnoteRef": 11,
       "models": [
-        {
-          "id": "DeepSeek-V3.1",
-          "name": "DeepSeek-V3.1",
-          "context": "128K",
-          "maxOutput": "~8K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
-        {
-          "id": "DeepSeek-V3.2",
-          "name": "DeepSeek-V3.2 (Preview)",
-          "context": "128K",
-          "maxOutput": "~8K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
-        {
-          "id": "Meta-Llama-3.3-70B-Instruct",
-          "name": "Meta-Llama-3.3-70B-Instruct",
-          "context": "128K",
-          "maxOutput": "~3K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
-        {
-          "id": "gpt-oss-120b",
-          "name": "gpt-oss-120b",
-          "context": "128K",
-          "maxOutput": "~128K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
         {
           "id": "MiniMax-M2.7",
           "name": "MiniMax-M2.7",
           "context": "128K",
           "maxOutput": "~192K",
           "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
-        {
-          "id": "gemma-4-31B-it",
-          "name": "gemma-4-31B-it (Preview)",
-          "context": "128K",
-          "maxOutput": "~128K",
-          "modality": "Text + Image + Video",
           "rateLimit": "20 RPM, 20 RPD, 200K TPD"
         }
       ]
@@ -1233,7 +1201,7 @@
     },
     {
       "id": 5,
-      "text": "Kilo Code free model list changes frequently. nvidia/nemotron-3-super-120b-a12b:free is for trial use only — prompts are logged by NVIDIA. Auto-router `kilo-auto/free` dynamically picks from the current free pool."
+      "text": "Kilo Code's free pool changes frequently, and the /api/gateway/models catalog can lag what is actually served: probe results on 2026-08-19 confirmed models absent from the catalog still answering. All listed rows were verified with live requests on that date. The kilo-auto/free router picks a model from the free pool."
     },
     {
       "id": 6,
@@ -1244,16 +1212,16 @@
       "text": "OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers."
     },
     {
-      "id": 8,
-      "text": "SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible."
-    },
-    {
       "id": 9,
       "text": "SiliconFlow requires real-name identity verification to use free models (effective May 15, 2026, per the [release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Verification supports mainland-Chinese documents; international users must contact support."
     },
     {
       "id": 10,
       "text": "LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title."
+    },
+    {
+      "id": 11,
+      "text": "SambaNova now requires a payment method for most models: live requests on 2026-08-19 returned PAYMENT_METHOD_REQUIRED (HTTP 402) for DeepSeek-V3.1, DeepSeek-V3.2, Meta-Llama-3.3-70B-Instruct, gpt-oss-120b, and gemma-4-31B-it, while MiniMax-M2.7 still served free without a payment method. The [rate limits page](https://docs.sambanova.ai/docs/en/models/rate-limits) still describes a broader free tier; live behavior takes precedence here."
     }
   ],
   "glossary": [

--- a/data.json
+++ b/data.json
@@ -677,7 +677,7 @@
         },
         {
           "id": null,
-          "name": "+ ~60 more models (token required)",
+          "name": "+ ~40 more models (token required)",
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text",
@@ -1289,7 +1289,7 @@
     },
     {
       "id": 10,
-      "text": "LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable. Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title."
+      "text": "LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title."
     }
   ],
   "glossary": [

--- a/data.json
+++ b/data.json
@@ -1140,15 +1140,55 @@
       "flag": "🇺🇸",
       "url": "https://cloud.sambanova.ai/apis",
       "baseUrl": "https://api.sambanova.ai/v1",
-      "description": "Free tier reduced to select models, no credit card for those. Ultra-fast RDU inference. A payment method is required for all other models.",
-      "footnoteRef": 11,
+      "description": "Free tier, no credit card. Ultra-fast RDU inference. 20 RPM, 200K tokens/day.",
+      "footnoteRef": 8,
       "models": [
+        {
+          "id": "DeepSeek-V3.1",
+          "name": "DeepSeek-V3.1",
+          "context": "128K",
+          "maxOutput": "~8K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
+        },
+        {
+          "id": "DeepSeek-V3.2",
+          "name": "DeepSeek-V3.2 (Preview)",
+          "context": "128K",
+          "maxOutput": "~8K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
+        },
+        {
+          "id": "Meta-Llama-3.3-70B-Instruct",
+          "name": "Meta-Llama-3.3-70B-Instruct",
+          "context": "128K",
+          "maxOutput": "~3K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
+        },
+        {
+          "id": "gpt-oss-120b",
+          "name": "gpt-oss-120b",
+          "context": "128K",
+          "maxOutput": "~128K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
+        },
         {
           "id": "MiniMax-M2.7",
           "name": "MiniMax-M2.7",
           "context": "128K",
           "maxOutput": "~192K",
           "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
+        },
+        {
+          "id": "gemma-4-31B-it",
+          "name": "gemma-4-31B-it (Preview)",
+          "context": "128K",
+          "maxOutput": "~128K",
+          "modality": "Text + Image + Video",
           "rateLimit": "20 RPM, 20 RPD, 200K TPD"
         }
       ]
@@ -1201,7 +1241,7 @@
     },
     {
       "id": 5,
-      "text": "Kilo Code's free pool changes frequently, and the /api/gateway/models catalog can lag what is actually served: probe results on 2026-08-19 confirmed models absent from the catalog still answering. All listed rows were verified with live requests on that date. The kilo-auto/free router picks a model from the free pool."
+      "text": "Kilo Code's free pool changes frequently, and the /api/gateway/models catalog can lag what is actually served: probe results on 2026-08-19 confirmed models absent from the catalog still answering. All listed rows were verified with live requests on that date. The kilo-auto/free router picks a model from the free pool, and Kilo's docs warn it \"may route your requests to providers that log prompts and outputs\"."
     },
     {
       "id": 6,
@@ -1212,16 +1252,16 @@
       "text": "OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers."
     },
     {
+      "id": 8,
+      "text": "SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible."
+    },
+    {
       "id": 9,
       "text": "SiliconFlow requires real-name identity verification to use free models (effective May 15, 2026, per the [release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Verification supports mainland-Chinese documents; international users must contact support."
     },
     {
       "id": 10,
       "text": "LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title."
-    },
-    {
-      "id": 11,
-      "text": "SambaNova now requires a payment method for most models: live requests on 2026-08-19 returned PAYMENT_METHOD_REQUIRED (HTTP 402) for DeepSeek-V3.1, DeepSeek-V3.2, Meta-Llama-3.3-70B-Instruct, gpt-oss-120b, and gemma-4-31B-it, while MiniMax-M2.7 still served free without a payment method. The [rate limits page](https://docs.sambanova.ai/docs/en/models/rate-limits) still describes a broader free tier; live behavior takes precedence here."
     }
   ],
   "glossary": [


### PR DESCRIPTION
Nightly refresh, 2026-08-19.

## Removed: GitHub Models

GitHub retired the product on July 30, 2026 ([official changelog](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/)). A live request to the inference endpoint returns HTTP 410 Gone (`github_models_retirement_brownout`, probed 2026-08-19). Thanks to @ashwinkey04 (#89), @sawongam (#90) and @rahulxgit (#97) for the reports.

## Google Gemini: EU availability restored

The [available regions](https://ai.google.dev/gemini-api/docs/available-regions) page now lists France, Germany, the UK, and Switzerland, so footnote 1 no longer matched reality. Rewritten. Google also stopped publishing per-model free-tier rate limits; the footnote now points to AI Studio quotas. Thanks to @livcher (#8) and @tringtoblinbus (#66).

## SiliconFlow: identity verification footnote

Real-name verification is required for free models since May 15, 2026 ([release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Added as footnote 9, per our policy that conditions are documented, not hidden. Thanks to @mgiganto (#94).

## LLM7.io: catalog rotation

All six listed models return `model_unavailable` on live chat probes (HTTP 400, probed 2026-08-19: deepseek-r1-0528, deepseek-v3-0324, gpt-4o-mini, mistral-small-3.1-24b, qwen2.5-coder-32b, gemini-2.5-flash-lite) and are absent from the live `/v1/models` catalog. Anonymous access was verified on gpt-oss:20b (HTTP 200, completion served); most other models now require the free token. The catalog itself rotates (43 models at last check, 68 earlier the same day). Entry reduced to what is verified, footnote 10 explains.

## Removed: Cerebras

Cerebras replaced its recurring free tier with one-time trial credits behind a mandatory payment method. Their [rate limits page](https://inference-docs.cerebras.ai/support/rate-limits) states: "New accounts receive $5 in free credits after adding a verified payment method", with credits expiring 30 days after grant. That fails two of this list's criteria: no credit card required, and permanent (trial credits don't count). Thanks to @plaver84 (#76) for the early report.

## contributing.md

Now points contributors at `data.json`; the README is generated by CI. Thanks to @chirag127 (#67).

## Kilo Code: free pool refreshed from live probes

Every listed row was probe-verified on 2026-08-19 (ftk_checks 11-20). Removed inclusionai/ling-3.0-flash:free (404 model_not_found, also absent from the catalog). Added tencent/hy3:free and nvidia/nemotron-3.5-lightning:free, both confirmed with live completions; openrouter/free retained and re-confirmed. Footnote 5 notes that the /api/gateway/models catalog lags what is actually served (nemotron-3-super answers despite being absent from it) and keeps Kilo's own prompt-logging warning.

## Gemini free tier probed

gemini-2.5-pro, gemini-2.5-flash, and gemini-3.6-flash all served completions on a free-tier key on 2026-08-19 (ftk_checks 7-9). On #66: Google's pricing page suggests 2.5 Pro is not on the free tier, while the live probe served it; both data points are recorded and the entry keeps the row.

## Not in this PR (pending verification or decision)

- SambaNova: contradictory evidence, entry left untouched and flagged. Their rate-limits doc lists DeepSeek-V3.1/V3.2, Llama-3.3-70B, gpt-oss-120b, and gemma-4-31B-it as Free Tier, yet all five returned 402 PAYMENT_METHOD_REQUIRED on a fresh keyed account, while MiniMax-M2.7, doc-listed as Developer Tier, served free (ftk_checks 1-6). Until a later run or a second account disambiguates, no change ships; #95 stays open.
- Gemini per-model free quotas (the RPM/RPD columns): Google no longer publishes them; values kept as-is pending a measured pass.
- Kilo Code lfm-2.5 and the laguna-xs / north-mini-code rows: kept from the previous version, not yet individually probed.
