### PR TITLE
Audit refresh: Aion Labs, Cohere, Cloudflare, Z AI, Mistral (29 corrections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,18 @@
 
 APIs run by the companies that train or fine-tune the models themselves.
 
-### [Aion Labs](https://www.aionlabs.ai) 🇮🇱
+### [Aion Labs](https://www.aionlabs.ai/app/api-keys/) 🇮🇱
 
 Permanent free tier, no credit card required. 15 RPM, 20K tokens/day. Specialized for roleplay and storytelling.
 
 Base URL: `https://api.aionlabs.ai/v1`
 
-| Model Name       | Context | Max Output | Modality                   | Rate Limit      |
-| ---------------- | ------- | ---------- | -------------------------- | --------------- |
-| Aion 2.5         | 128K    | 32K        | Text (roleplay)            | 15 RPM, 20K TPD |
-| Aion 2.0         | 128K    | 32K        | Text (roleplay)            | 15 RPM, 20K TPD |
-| Aion-RP 1.0 (8B) | 32K     | 32K        | Text (roleplay)            | 15 RPM, 20K TPD |
-| Aion 3.0         | 128K    | 32K        | Text (roleplay, reasoning) | 15 RPM, 20K TPD |
-| Aion 3.0 Mini    | 128K    | 32K        | Text (roleplay, reasoning) | 15 RPM, 20K TPD |
+| Model Name                       | Context | Max Output | Modality                   | Rate Limit      |
+| -------------------------------- | ------- | ---------- | -------------------------- | --------------- |
+| `aion-labs/aion-2.0`             | 128K    | 32K        | Text (roleplay)            | 15 RPM, 20K TPD |
+| `aion-labs/aion-rp-llama-3.1-8b` | 32K     | 32K        | Text (roleplay)            | 15 RPM, 20K TPD |
+| `aion-labs/aion-3.0`             | 128K    | 32K        | Text (roleplay, reasoning) | 15 RPM, 20K TPD |
+| `aion-labs/aion-3.0-mini`        | 128K    | 32K        | Text (roleplay, reasoning) | 15 RPM, 20K TPD |
 
 ### [Cohere](https://dashboard.cohere.com/api-keys) 🇨🇦
 
@@ -59,17 +58,17 @@ Base URL: `https://api.cohere.com/v2`
 
 | Model Name          | Context | Max Output | Modality         | Rate Limit |
 | ------------------- | ------- | ---------- | ---------------- | ---------- |
-| Command A+ (218B)   | 436K    | 64K        | Text + Image     | 20 RPM     |
-| Command A (111B)    | 288K    | 8K         | Text             | 20 RPM     |
+| Command A+ (218B)   | 128K    | 64K        | Text + Image     | 20 RPM     |
+| Command A (111B)    | 256K    | 8K         | Text             | 20 RPM     |
 | Command R+          | 128K    | 4K         | Text             | 20 RPM     |
 | Command R           | 128K    | 4K         | Text             | 20 RPM     |
 | Command R7B         | 128K    | 4K         | Text             | 20 RPM     |
-| Command A Reasoning | 288K    | ~4K        | Text (reasoning) | 20 RPM     |
-| Command A Translate | ~9K     | ~4K        | Text             | 20 RPM     |
-| Command A Vision    | 128K    | ~4K        | Text + Image     | 20 RPM     |
+| Command A Reasoning | 256K    | 32K        | Text (reasoning) | 20 RPM     |
+| Command A Translate | 8K      | 8K         | Text             | 20 RPM     |
+| Command A Vision    | 128K    | 8K         | Text + Image     | 20 RPM     |
 | Command R7B Arabic  | 128K    | ~4K        | Text             | 20 RPM     |
-| Aya Expanse 32B     | 128K    | ~4K        | Text             | 20 RPM     |
-| Aya Vision 32B      | 16K     | ~4K        | Text + Image     | 20 RPM     |
+| Aya Expanse 32B     | 128K    | 4K         | Text             | 20 RPM     |
+| Aya Vision 32B      | 16K     | 4K         | Text + Image     | 20 RPM     |
 
 ### [Google Gemini](https://aistudio.google.com/app/apikey) 🇺🇸
 
@@ -89,31 +88,31 @@ Base URL: `https://generativelanguage.googleapis.com/v1beta`
 
 ### [Mistral AI](https://console.mistral.ai/api-keys) 🇫🇷
 
-Free "Experiment" plan, no credit card. ~1B tokens/month. Prompts may be used to improve models.
+Free mode, enabled by default, no credit card required. $10/month in API credits, and free-mode prompts may be used to train Mistral models unless you opt out. [^13]
 
 Base URL: `https://api.mistral.ai/v1`
 
 | Model Name                | Context | Max Output | Modality            | Rate Limit       |
 | ------------------------- | ------- | ---------- | ------------------- | ---------------- |
-| Mistral Medium 3.5 (128B) | 256K    | 256K       | Text + Image + Code | ~1 RPS, 500K TPM |
-| Mistral Small 4           | 256K    | 256K       | Text + Image + Code | ~1 RPS, 500K TPM |
-| Mistral Large 3           | 256K    | 256K       | Text                | ~1 RPS, 500K TPM |
-| Ministral 8B              | 256K    | 256K       | Text                | ~1 RPS, 500K TPM |
-| Codestral                 | 256K    | 256K       | Code                | ~1 RPS, 500K TPM |
-| Ministral 3B              | 128K    | 128K       | Text                | ~1 RPS, 500K TPM |
-| Ministral 14B             | 256K    | 256K       | Text                | ~1 RPS, 500K TPM |
+| Mistral Medium 3.5 (128B) | 256K    | —          | Text + Image + Code | ~1 RPS, 500K TPM |
+| Mistral Small 4           | 256K    | —          | Text + Image + Code | ~1 RPS, 500K TPM |
+| Mistral Large 3           | 256K    | —          | Multimodal          | ~1 RPS, 500K TPM |
+| Ministral 3 8B            | 256K    | —          | Text                | ~1 RPS, 500K TPM |
+| Codestral                 | 128K    | —          | Code                | ~1 RPS, 500K TPM |
+| Ministral 3 3B            | 256K    | —          | Text                | ~1 RPS, 500K TPM |
+| Ministral 3 14B           | 256K    | —          | Text                | ~1 RPS, 500K TPM |
 
 ### [Z AI (Zhipu AI)](https://open.bigmodel.cn/usercenter/apikeys) 🇨🇳
 
-Permanent free models, no credit card required.
+Permanent free models, no credit card required. [^12]
 
 Base URL: `https://open.bigmodel.cn/api/paas/v4`
 
-| Model Name     | Context | Max Output | Modality         | Rate Limit           |
-| -------------- | ------- | ---------- | ---------------- | -------------------- |
-| GLM-4.7-Flash  | 200K    | 128K       | Text (reasoning) | 1 concurrent request |
-| GLM-4.5-Flash  | 128K    | ~96K       | Text (reasoning) | 1 concurrent request |
-| GLM-4.6V-Flash | 128K    | ~4K        | Text + Image     | 1 concurrent request |
+| Model Name                           | Context | Max Output | Modality         | Rate Limit           |
+| ------------------------------------ | ------- | ---------- | ---------------- | -------------------- |
+| GLM-4.7-Flash                        | 200K    | 128K       | Text (reasoning) | 1 concurrent request |
+| GLM-4.5-Flash (retirement announced) | 128K    | 96K        | Text (reasoning) | 1 concurrent request |
+| GLM-4.6V-Flash                       | 128K    | 32K        | Multimodal       | 1 concurrent request |
 
 ## Inference providers
 
@@ -121,21 +120,20 @@ Third-party platforms that host open-weight models from various sources.
 
 ### [Cloudflare Workers AI](https://dash.cloudflare.com/profile/api-tokens) 🇺🇸
 
-10,000 Neurons/day free. 50+ models available on free tier.
+10,000 Neurons/day free, no credit card required. 75+ models available on the free tier. [^11]
 
 Base URL: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run`
 
-| Model Name                                     | Context   | Max Output        | Modality                       | Rate Limit               |
-| ---------------------------------------------- | --------- | ----------------- | ------------------------------ | ------------------------ |
-| `@cf/meta/llama-3.3-70b-instruct-fp8-fast`     | 131K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
-| `@cf/meta/llama-4-scout-17b-16e-instruct`      | Up to 10M | Shared w/ context | Multimodal                     | 10K neurons/day (shared) |
-| `@cf/openai/gpt-oss-120b`                      | 128K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
-| `@cf/moonshotai/kimi-k2.7-code`                | 262K      | Shared w/ context | Text (code)                    | 10K neurons/day (shared) |
-| `@cf/google/gemma-4-26b-a4b-it`                | 256K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
-| `@cf/zhipuai/glm-4.7-flash`                    | 131K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
-| `@cf/mistralai/mistral-small-3.1-24b-instruct` | 128K      | Shared w/ context | Text                           | 10K neurons/day (shared) |
-| `@cf/deepseek-ai/deepseek-r1-distill-qwen-32b` | 32K       | Shared w/ context | Text (reasoning)               | 10K neurons/day (shared) |
-| + 42 more models                               | Varies    | Varies            | Text, Image, Audio, Embeddings | 10K neurons/day (shared) |
+| Model Name                                     | Context | Max Output        | Modality                       | Rate Limit               |
+| ---------------------------------------------- | ------- | ----------------- | ------------------------------ | ------------------------ |
+| `@cf/meta/llama-3.3-70b-instruct-fp8-fast`     | 24K     | Shared w/ context | Text                           | 10K neurons/day (shared) |
+| `@cf/meta/llama-4-scout-17b-16e-instruct`      | 131K    | Shared w/ context | Multimodal                     | 10K neurons/day (shared) |
+| `@cf/openai/gpt-oss-120b`                      | 128K    | Shared w/ context | Text                           | 10K neurons/day (shared) |
+| `@cf/google/gemma-4-26b-a4b-it`                | 256K    | Shared w/ context | Text                           | 10K neurons/day (shared) |
+| `@cf/zai-org/glm-4.7-flash`                    | 131K    | Shared w/ context | Text                           | 10K neurons/day (shared) |
+| `@cf/mistralai/mistral-small-3.1-24b-instruct` | 128K    | Shared w/ context | Text                           | 10K neurons/day (shared) |
+| `@cf/deepseek-ai/deepseek-r1-distill-qwen-32b` | 80K     | Shared w/ context | Text (reasoning)               | 10K neurons/day (shared) |
+| + 72 more models                               | Varies  | Varies            | Text, Image, Audio, Embeddings | 10K neurons/day (shared) |
 
 ### [Groq](https://console.groq.com/keys) 🇺🇸
 
@@ -345,3 +343,6 @@ Know a free tier that's missing? [Open a PR](contributing.md). Include the provi
 [^8]: SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible.
 [^9]: SiliconFlow requires real-name identity verification to use free models (effective May 15, 2026, per the [release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Verification supports mainland-Chinese documents; international users must contact support.
 [^10]: LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title.
+[^11]: The 10,000 free Neurons are shared across all Workers AI usage, not per model, and all limits reset daily at 00:00 UTC. Going over does not bill you, the request fails. Five models are excluded from Workers Free billing and need the Workers Paid plan or prepaid AI Gateway credits: `@cf/moonshotai/kimi-k2.6`, `@cf/moonshotai/kimi-k2.7-code`, `@cf/zai-org/glm-5.2`, `@cf/deepseek-ai/deepseek-v4-flash-0731`, `@cf/deepseek-ai/deepseek-v4-pro-0813` ([pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/)).
+[^12]: Registration accepts overseas phone numbers ([registration FAQ](https://docs.bigmodel.cn/cn/faq/registration-login.md)) and the chat API does not require real-name verification: 目前调用 API 并不强制要求实名认证 ([authentication FAQ](https://docs.bigmodel.cn/cn/faq/authentication-issues.md)). The Batch API does require it ([batch FAQ](https://docs.bigmodel.cn/cn/faq/batch-api-issues.md)). The same free models are served from the international platform at `https://api.z.ai/api/paas/v4` ([endpoint](https://docs.z.ai/guides/develop/http/introduction)), where GLM-4.7-Flash, GLM-4.5-Flash and GLM-4.6V-Flash are all priced Free ([pricing](https://docs.z.ai/guides/overview/pricing.md)). Z AI has announced that GLM-4.5-Flash will be retired and its requests auto-routed to GLM-4.7-Flash ([model page](https://docs.bigmodel.cn/cn/guide/models/free/glm-4.5-flash.md)); the announced date has already passed while the model is still catalogued and still priced Free, so treat that row as living on borrowed time.
+[^13]: Mistral plans are global: the monthly allowance is shared across Studio, the API, and Vibe Code, so CLI usage eats the same budget ([subscriptions](https://docs.mistral.ai/admin/user-management-finops/subscriptions)). Free mode is the default for new accounts and needs no credit card ([quickstart](https://docs.mistral.ai/getting-started/quickstarts/studio/activate-and-generate-api-key)). Free-mode inputs and outputs may be used to train Mistral models, and you can opt out at any time ([data usage](https://help.mistral.ai/en/articles/347617-do-you-use-my-user-data-to-train-your-artificial-intelligence-models)). Mistral no longer publishes numeric free-tier rate limits and points you at the Limits page of the admin panel instead ([rate limits](https://help.mistral.ai/en/articles/698531-why-am-i-hitting-api-rate-limits-and-how-do-i-increase-them)); the rate limit column is kept from the last published values.

--- a/data.json
+++ b/data.json
@@ -6,46 +6,38 @@
       "category": "provider_api",
       "country": "IL",
       "flag": "🇮🇱",
-      "url": "https://www.aionlabs.ai",
+      "url": "https://www.aionlabs.ai/app/api-keys/",
       "baseUrl": "https://api.aionlabs.ai/v1",
       "description": "Permanent free tier, no credit card required. 15 RPM, 20K tokens/day. Specialized for roleplay and storytelling.",
       "footnoteRef": null,
       "models": [
         {
-          "id": "aion-2.5",
-          "name": "Aion 2.5",
+          "id": "aion-labs/aion-2.0",
+          "name": "aion-labs/aion-2.0",
           "context": "128K",
           "maxOutput": "32K",
           "modality": "Text (roleplay)",
           "rateLimit": "15 RPM, 20K TPD"
         },
         {
-          "id": "aion-2.0",
-          "name": "Aion 2.0",
-          "context": "128K",
-          "maxOutput": "32K",
-          "modality": "Text (roleplay)",
-          "rateLimit": "15 RPM, 20K TPD"
-        },
-        {
-          "id": "aion-rp-llama-3.1-8b",
-          "name": "Aion-RP 1.0 (8B)",
+          "id": "aion-labs/aion-rp-llama-3.1-8b",
+          "name": "aion-labs/aion-rp-llama-3.1-8b",
           "context": "32K",
           "maxOutput": "32K",
           "modality": "Text (roleplay)",
           "rateLimit": "15 RPM, 20K TPD"
         },
         {
-          "id": "aion-3.0",
-          "name": "Aion 3.0",
+          "id": "aion-labs/aion-3.0",
+          "name": "aion-labs/aion-3.0",
           "context": "128K",
           "maxOutput": "32K",
           "modality": "Text (roleplay, reasoning)",
           "rateLimit": "15 RPM, 20K TPD"
         },
         {
-          "id": "aion-3.0-mini",
-          "name": "Aion 3.0 Mini",
+          "id": "aion-labs/aion-3.0-mini",
+          "name": "aion-labs/aion-3.0-mini",
           "context": "128K",
           "maxOutput": "32K",
           "modality": "Text (roleplay, reasoning)",
@@ -66,7 +58,7 @@
         {
           "id": "command-a-plus-05-2026",
           "name": "Command A+ (218B)",
-          "context": "436K",
+          "context": "128K",
           "maxOutput": "64K",
           "modality": "Text + Image",
           "rateLimit": "20 RPM"
@@ -74,7 +66,7 @@
         {
           "id": "command-a-03-2025",
           "name": "Command A (111B)",
-          "context": "288K",
+          "context": "256K",
           "maxOutput": "8K",
           "modality": "Text",
           "rateLimit": "20 RPM"
@@ -106,16 +98,16 @@
         {
           "id": "command-a-reasoning-08-2025",
           "name": "Command A Reasoning",
-          "context": "288K",
-          "maxOutput": "~4K",
+          "context": "256K",
+          "maxOutput": "32K",
           "modality": "Text (reasoning)",
           "rateLimit": "20 RPM"
         },
         {
           "id": "command-a-translate-08-2025",
           "name": "Command A Translate",
-          "context": "~9K",
-          "maxOutput": "~4K",
+          "context": "8K",
+          "maxOutput": "8K",
           "modality": "Text",
           "rateLimit": "20 RPM"
         },
@@ -123,7 +115,7 @@
           "id": "command-a-vision-07-2025",
           "name": "Command A Vision",
           "context": "128K",
-          "maxOutput": "~4K",
+          "maxOutput": "8K",
           "modality": "Text + Image",
           "rateLimit": "20 RPM"
         },
@@ -139,7 +131,7 @@
           "id": "c4ai-aya-expanse-32b",
           "name": "Aya Expanse 32B",
           "context": "128K",
-          "maxOutput": "~4K",
+          "maxOutput": "4K",
           "modality": "Text",
           "rateLimit": "20 RPM"
         },
@@ -147,7 +139,7 @@
           "id": "c4ai-aya-vision-32b",
           "name": "Aya Vision 32B",
           "context": "16K",
-          "maxOutput": "~4K",
+          "maxOutput": "4K",
           "modality": "Text + Image",
           "rateLimit": "20 RPM"
         }
@@ -228,14 +220,14 @@
       "flag": "🇫🇷",
       "url": "https://console.mistral.ai/api-keys",
       "baseUrl": "https://api.mistral.ai/v1",
-      "description": "Free \"Experiment\" plan, no credit card. ~1B tokens/month. Prompts may be used to improve models.",
-      "footnoteRef": null,
+      "description": "Free mode, enabled by default, no credit card required. $10/month in API credits, and free-mode prompts may be used to train Mistral models unless you opt out.",
+      "footnoteRef": 13,
       "models": [
         {
           "id": "mistral-medium-2604",
           "name": "Mistral Medium 3.5 (128B)",
           "context": "256K",
-          "maxOutput": "256K",
+          "maxOutput": "—",
           "modality": "Text + Image + Code",
           "rateLimit": "~1 RPS, 500K TPM"
         },
@@ -243,7 +235,7 @@
           "id": "mistral-small-2603",
           "name": "Mistral Small 4",
           "context": "256K",
-          "maxOutput": "256K",
+          "maxOutput": "—",
           "modality": "Text + Image + Code",
           "rateLimit": "~1 RPS, 500K TPM"
         },
@@ -251,39 +243,39 @@
           "id": "mistral-large-2512",
           "name": "Mistral Large 3",
           "context": "256K",
-          "maxOutput": "256K",
-          "modality": "Text",
+          "maxOutput": "—",
+          "modality": "Multimodal",
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
           "id": "ministral-8b-2512",
-          "name": "Ministral 8B",
+          "name": "Ministral 3 8B",
           "context": "256K",
-          "maxOutput": "256K",
+          "maxOutput": "—",
           "modality": "Text",
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
           "id": "codestral-2508",
           "name": "Codestral",
-          "context": "256K",
-          "maxOutput": "256K",
+          "context": "128K",
+          "maxOutput": "—",
           "modality": "Code",
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
           "id": "ministral-3b-2512",
-          "name": "Ministral 3B",
-          "context": "128K",
-          "maxOutput": "128K",
+          "name": "Ministral 3 3B",
+          "context": "256K",
+          "maxOutput": "—",
           "modality": "Text",
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
           "id": "ministral-14b-2512",
-          "name": "Ministral 14B",
+          "name": "Ministral 3 14B",
           "context": "256K",
-          "maxOutput": "256K",
+          "maxOutput": "—",
           "modality": "Text",
           "rateLimit": "~1 RPS, 500K TPM"
         }
@@ -297,7 +289,7 @@
       "url": "https://open.bigmodel.cn/usercenter/apikeys",
       "baseUrl": "https://open.bigmodel.cn/api/paas/v4",
       "description": "Permanent free models, no credit card required.",
-      "footnoteRef": null,
+      "footnoteRef": 12,
       "models": [
         {
           "id": "glm-4.7-flash",
@@ -309,9 +301,9 @@
         },
         {
           "id": "glm-4.5-flash",
-          "name": "GLM-4.5-Flash",
+          "name": "GLM-4.5-Flash (retirement announced)",
           "context": "128K",
-          "maxOutput": "~96K",
+          "maxOutput": "96K",
           "modality": "Text (reasoning)",
           "rateLimit": "1 concurrent request"
         },
@@ -319,8 +311,8 @@
           "id": "glm-4.6v-flash",
           "name": "GLM-4.6V-Flash",
           "context": "128K",
-          "maxOutput": "~4K",
-          "modality": "Text + Image",
+          "maxOutput": "32K",
+          "modality": "Multimodal",
           "rateLimit": "1 concurrent request"
         }
       ]
@@ -332,13 +324,13 @@
       "flag": "🇺🇸",
       "url": "https://dash.cloudflare.com/profile/api-tokens",
       "baseUrl": "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run",
-      "description": "10,000 Neurons/day free. 50+ models available on free tier.",
-      "footnoteRef": null,
+      "description": "10,000 Neurons/day free, no credit card required. 75+ models available on the free tier.",
+      "footnoteRef": 11,
       "models": [
         {
           "id": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
           "name": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-          "context": "131K",
+          "context": "24K",
           "maxOutput": "Shared w/ context",
           "modality": "Text",
           "rateLimit": "10K neurons/day (shared)"
@@ -346,7 +338,7 @@
         {
           "id": "@cf/meta/llama-4-scout-17b-16e-instruct",
           "name": "@cf/meta/llama-4-scout-17b-16e-instruct",
-          "context": "Up to 10M",
+          "context": "131K",
           "maxOutput": "Shared w/ context",
           "modality": "Multimodal",
           "rateLimit": "10K neurons/day (shared)"
@@ -360,14 +352,6 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
-          "id": "@cf/moonshotai/kimi-k2.7-code",
-          "name": "@cf/moonshotai/kimi-k2.7-code",
-          "context": "262K",
-          "maxOutput": "Shared w/ context",
-          "modality": "Text (code)",
-          "rateLimit": "10K neurons/day (shared)"
-        },
-        {
           "id": "@cf/google/gemma-4-26b-a4b-it",
           "name": "@cf/google/gemma-4-26b-a4b-it",
           "context": "256K",
@@ -376,8 +360,8 @@
           "rateLimit": "10K neurons/day (shared)"
         },
         {
-          "id": "@cf/zhipuai/glm-4.7-flash",
-          "name": "@cf/zhipuai/glm-4.7-flash",
+          "id": "@cf/zai-org/glm-4.7-flash",
+          "name": "@cf/zai-org/glm-4.7-flash",
           "context": "131K",
           "maxOutput": "Shared w/ context",
           "modality": "Text",
@@ -394,14 +378,14 @@
         {
           "id": "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
           "name": "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
-          "context": "32K",
+          "context": "80K",
           "maxOutput": "Shared w/ context",
           "modality": "Text (reasoning)",
           "rateLimit": "10K neurons/day (shared)"
         },
         {
           "id": null,
-          "name": "+ 42 more models",
+          "name": "+ 72 more models",
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text, Image, Audio, Embeddings",
@@ -1262,6 +1246,18 @@
     {
       "id": 10,
       "text": "LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title."
+    },
+    {
+      "id": 11,
+      "text": "The 10,000 free Neurons are shared across all Workers AI usage, not per model, and all limits reset daily at 00:00 UTC. Going over does not bill you, the request fails. Five models are excluded from Workers Free billing and need the Workers Paid plan or prepaid AI Gateway credits: `@cf/moonshotai/kimi-k2.6`, `@cf/moonshotai/kimi-k2.7-code`, `@cf/zai-org/glm-5.2`, `@cf/deepseek-ai/deepseek-v4-flash-0731`, `@cf/deepseek-ai/deepseek-v4-pro-0813` ([pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/))."
+    },
+    {
+      "id": 12,
+      "text": "Registration accepts overseas phone numbers ([registration FAQ](https://docs.bigmodel.cn/cn/faq/registration-login.md)) and the chat API does not require real-name verification: 目前调用 API 并不强制要求实名认证 ([authentication FAQ](https://docs.bigmodel.cn/cn/faq/authentication-issues.md)). The Batch API does require it ([batch FAQ](https://docs.bigmodel.cn/cn/faq/batch-api-issues.md)). The same free models are served from the international platform at `https://api.z.ai/api/paas/v4` ([endpoint](https://docs.z.ai/guides/develop/http/introduction)), where GLM-4.7-Flash, GLM-4.5-Flash and GLM-4.6V-Flash are all priced Free ([pricing](https://docs.z.ai/guides/overview/pricing.md)). Z AI has announced that GLM-4.5-Flash will be retired and its requests auto-routed to GLM-4.7-Flash ([model page](https://docs.bigmodel.cn/cn/guide/models/free/glm-4.5-flash.md)); the announced date has already passed while the model is still catalogued and still priced Free, so treat that row as living on borrowed time."
+    },
+    {
+      "id": 13,
+      "text": "Mistral plans are global: the monthly allowance is shared across Studio, the API, and Vibe Code, so CLI usage eats the same budget ([subscriptions](https://docs.mistral.ai/admin/user-management-finops/subscriptions)). Free mode is the default for new accounts and needs no credit card ([quickstart](https://docs.mistral.ai/getting-started/quickstarts/studio/activate-and-generate-api-key)). Free-mode inputs and outputs may be used to train Mistral models, and you can opt out at any time ([data usage](https://help.mistral.ai/en/articles/347617-do-you-use-my-user-data-to-train-your-artificial-intelligence-models)). Mistral no longer publishes numeric free-tier rate limits and points you at the Limits page of the admin panel instead ([rate limits](https://help.mistral.ai/en/articles/698531-why-am-i-hitting-api-rate-limits-and-how-do-i-increase-them)); the rate limit column is kept from the last published values."
     }
   ],
   "glossary": [


### PR DESCRIPTION
Nightly refresh, 2026-08-19.

## Removed: GitHub Models

GitHub retired the product on July 30, 2026 ([official changelog](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/)). A live request to the inference endpoint returns HTTP 410 Gone (`github_models_retirement_brownout`, probed 2026-08-19). Thanks to @ashwinkey04 (#89), @sawongam (#90) and @rahulxgit (#97) for the reports.

## Google Gemini: EU availability restored

The [available regions](https://ai.google.dev/gemini-api/docs/available-regions) page now lists France, Germany, the UK, and Switzerland, so footnote 1 no longer matched reality. Rewritten. Google also stopped publishing per-model free-tier rate limits; the footnote now points to AI Studio quotas. Thanks to @livcher (#8) and @tringtoblinbus (#66).

## SiliconFlow: identity verification footnote

Real-name verification is required for free models since May 15, 2026 ([release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Added as footnote 9, per our policy that conditions are documented, not hidden. Thanks to @mgiganto (#94).

## LLM7.io: catalog rotation

All six listed models return `model_unavailable` on live chat probes (HTTP 400, probed 2026-08-19: deepseek-r1-0528, deepseek-v3-0324, gpt-4o-mini, mistral-small-3.1-24b, qwen2.5-coder-32b, gemini-2.5-flash-lite) and are absent from the live `/v1/models` catalog. Anonymous access was verified on gpt-oss:20b (HTTP 200, completion served); most other models now require the free token. The catalog itself rotates (43 models at last check, 68 earlier the same day). Entry reduced to what is verified, footnote 10 explains.

## Removed: Cerebras

Cerebras replaced its recurring free tier with one-time trial credits behind a mandatory payment method. Their [rate limits page](https://inference-docs.cerebras.ai/support/rate-limits) states: "New accounts receive $5 in free credits after adding a verified payment method", with credits expiring 30 days after grant. That fails two of this list's criteria: no credit card required, and permanent (trial credits don't count). Thanks to @plaver84 (#76) for the early report.

## contributing.md

Now points contributors at `data.json`; the README is generated by CI. Thanks to @chirag127 (#67).

## Kilo Code: free pool refreshed from live probes

Every listed row was probe-verified on 2026-08-19 (ftk_checks 11-20). Removed inclusionai/ling-3.0-flash:free (404 model_not_found, also absent from the catalog). Added tencent/hy3:free and nvidia/nemotron-3.5-lightning:free, both confirmed with live completions; openrouter/free retained and re-confirmed. Footnote 5 notes that the /api/gateway/models catalog lags what is actually served (nemotron-3-super answers despite being absent from it) and keeps Kilo's own prompt-logging warning.

## Gemini free tier probed

gemini-2.5-pro, gemini-2.5-flash, and gemini-3.6-flash all served completions on a free-tier key on 2026-08-19 (ftk_checks 7-9). On #66: Google's pricing page suggests 2.5 Pro is not on the free tier, while the live probe served it; both data points are recorded and the entry keeps the row.

## Aion Labs: Aion 2.5 retired, model ids were wrong

Aion 2.5 is badged Expired on the [models page](https://www.aionlabs.ai/docs/models/) with a stated sunset of Aug. 14, 2026 and a pointer to aion-labs/aion-3.0 as its replacement, and it is gone from the live catalog: an unauthenticated `GET https://api.aionlabs.ai/v1/models` returned four models on 2026-08-19 (ftk_checks 27) and it is not among them. Row removed.

The bigger problem was the ids. We published `aion-2.0`, `aion-3.0`, `aion-3.0-mini` and `aion-rp-llama-3.1-8b`, but the API serves them namespaced as `aion-labs/aion-2.0` and so on, so anyone copying our table got a model-not-found. All four ids corrected against the same live catalog, and the table now prints the id itself rather than a prose name, the way the Kilo Code and OpenRouter tables already do. The title link now goes to the API key page instead of the homepage.

The free tier itself is unchanged and still qualifies: the pricing page shows a $0 Free Tier card, "no card required", and the rate limits page gives 15 RPM and a 20,000 daily token limit, which is exactly what we publish.

## Cohere: nine wrong numbers

No terms change. Trial keys are still free, still 1,000 API calls a month, still non-commercial only, and 20 RPM still holds for every Command row we list. But most of our numbers were off, and the [models table](https://docs.cohere.com/docs/models) is explicit:

| Row | Field | Was | Now |
| --- | --- | --- | --- |
| Command A+ | Context | 436K | 128K |
| Command A | Context | 288K | 256K |
| Command A Reasoning | Context | 288K | 256K |
| Command A Reasoning | Max Output | ~4K | 32K |
| Command A Translate | Context | ~9K | 8K |
| Command A Translate | Max Output | ~4K | 8K |
| Command A Vision | Max Output | ~4K | 8K |
| Aya Expanse 32B | Max Output | ~4K | 4K |
| Aya Vision 32B | Max Output | ~4K | 4K |

Command A+ was the worst of them: we advertised more than three times the real context window.

## Cloudflare Workers AI: one model is not free, and one id would 404

The [pricing page](https://developers.cloudflare.com/workers-ai/platform/pricing/) says it plainly: "Some models require a paid billing method. This applies to @cf/moonshotai/kimi-k2.6, @cf/moonshotai/kimi-k2.7-code, @cf/zai-org/glm-5.2, @cf/deepseek-ai/deepseek-v4-flash-0731, and @cf/deepseek-ai/deepseek-v4-pro-0813." We were listing `@cf/moonshotai/kimi-k2.7-code` as free. Row removed, and the full exclusion list is now in footnote 11 so nobody re-adds one of the other four.

We also published `@cf/zhipuai/glm-4.7-flash`. That vendor prefix does not exist in the catalog; the model is `@cf/zai-org/glm-4.7-flash`. Corrected.

Three context windows were wrong: llama-3.3-70b-instruct-fp8-fast is 24K, not 131K; llama-4-scout-17b-16e-instruct is 131K, not "Up to 10M"; deepseek-r1-distill-qwen-32b is 80K, not 32K.

The catalog counter reads "We found 84 models". Minus the five that need paid billing, and minus the seven rows we name, the filler row becomes "+ 72 more models" and the description says 75+ instead of 50+. Footnote 11 also records that the 10,000 Neurons are shared across all Workers AI usage, that everything resets daily at 00:00 UTC, and that going over fails the request rather than billing you.

## Mistral AI: the free tier changed shape

Still in scope, still no credit card: "Free mode: API access is enabled by default with no credit card required" ([quickstart](https://docs.mistral.ai/getting-started/quickstarts/studio/activate-and-generate-api-key)). But almost everything around it moved.

The plan is no longer called "Experiment", it is Free mode, and it is the default for new accounts. The allowance is no longer expressed in tokens: [pricing](https://mistral.ai/pricing) now says "$10 /mo in API credits", and that budget is shared across Studio, the API and Vibe Code, so the CLI eats the same pot. The "~1B tokens/month" figure we published does not appear on any Mistral page any more.

Two contexts were wrong: Codestral is 128K, not 256K, and Ministral 3 3B is 256K, not 128K. Mistral Large 3 is multimodal, not text-only.

The three Ministral rows were named after the wrong models. "Ministral 8B" and "Ministral 3B" are the retired 2410 models; the ones we list, `ministral-8b-2512` and friends, are the Ministral 3 family. Renamed to Ministral 3 8B, Ministral 3 3B and Ministral 3 14B.

Max Output is now "—" on all seven rows. Mistral publishes no max-output figure for any of them, and defines context as input plus output combined, so copying the context value across was never right. The Codestral row proved it: it claimed 256K of output from a 128K window.

Footnote 13 carries the shared-budget point, the training opt-out (free-mode data may be used for training and you can opt out at any time), and a warning that the rate limit numbers are the last ones Mistral published before [moving them behind the admin panel](https://help.mistral.ai/en/articles/698531-why-am-i-hitting-api-rate-limits-and-how-do-i-increase-them).

## Z AI: the verification worry was wrong

We had a standing suspicion that Z AI required mainland-China real-name verification, the way SiliconFlow does. Their own [authentication FAQ](https://docs.bigmodel.cn/cn/faq/authentication-issues.md) says otherwise: "目前调用 API 并不强制要求实名认证" ("calling the API does not mandatorily require real-name verification"), and registration [accepts overseas phone numbers](https://docs.bigmodel.cn/cn/faq/registration-login.md). The [Batch API](https://docs.bigmodel.cn/cn/faq/batch-api-issues.md) does require verification, and we do not list batch endpoints. No warning footnote was added, and the assumption is dropped.

GLM-4.6V-Flash max output is 32K, not ~4K, and it takes video and files as well as images, so its modality is Multimodal. GLM-4.5-Flash max output is exactly 96K, so the tilde goes.

One thing to flag rather than hide: Z AI has announced that GLM-4.5-Flash is being retired, with requests auto-routed to GLM-4.7-Flash. The announced date, January 30 2026, has already passed, and the model is still in the catalogue and still priced Free on both platforms. That is two official pages disagreeing, so the row stays with the announcement marked on it rather than being pulled on a date that evidently did not hold. Footnote 12 carries that, the access conditions, and the international endpoint `https://api.z.ai/api/paas/v4` for anyone who would rather not use the mainland platform.

## Not in this PR (pending verification or decision)

- SambaNova: contradictory evidence, entry left untouched and flagged. Their rate-limits doc lists DeepSeek-V3.1/V3.2, Llama-3.3-70B, gpt-oss-120b, and gemma-4-31B-it as Free Tier, yet all five returned 402 PAYMENT_METHOD_REQUIRED on a fresh keyed account, while MiniMax-M2.7, doc-listed as Developer Tier, served free (ftk_checks 1-6). Until a later run or a second account disambiguates, no change ships; #95 stays open.
- Gemini per-model free quotas (the RPM/RPD columns): Google no longer publishes them; values kept as-is pending a measured pass.
- Kilo Code lfm-2.5 and the laguna-xs / north-mini-code rows: kept from the previous version, not yet individually probed.
- Cohere `command-r7b-arabic-02-2025`: gone from the models inventory, its docs page 404s, and it never appeared on the deprecations page. That is one proof short of what a removal needs, and we hold no Cohere key to probe with, so the row stays and the model is flagged.
- Cohere Tiny Aya (tiny-aya-global, -earth, -fire, -water) and Z AI glm-4-flash-250414, glm-4.1v-thinking-flash, glm-4v-flash: seven free models we could add, all blocked on the same thing, no key to confirm them with a real request.
- Mistral `zai-glm-5-2`: in the catalog since 2026-08-06, free-mode availability not documented, no key to probe. Left off.
- Z AI "1 concurrent request" and Mistral "~1 RPS, 500K TPM": both providers moved their numeric limits behind login. Values kept as the last published ones, with footnote 13 saying so for Mistral.
