### PR TITLE
fix: OpenRouter google/gemma-4-26b-a4b-it:free also supports video input

### DIFF
--- a/data.json
+++ b/data.json
@@ -940,7 +940,7 @@
           "name": "google/gemma-4-26b-a4b-it:free",
           "context": "262K",
           "maxOutput": "32K",
-          "modality": "Text + Image",
+          "modality": "Text + Image + Video",
           "rateLimit": "20 RPM, 50 RPD"
         },
         {


### PR DESCRIPTION
## Summary
- `google/gemma-4-26b-a4b-it:free`'s `modality` field was listed as `Text + Image`, missing video support.
- Verified against OpenRouter's model page: the endpoint accepts text, image, **and video** input (up to 60s @ 1fps). Updated to `Text + Image + Video`.
- Context (262K) and max output (32K) were already correct and unchanged.
- Also double-checked `nvidia/nemotron-3-super-120b-a12b:free` in the same entry — context/maxOutput (262K/262K) and the free-tier rate limit (20 RPM, 50 RPD) are accurate as-is; no change needed there.

## Docs confirming free tier / limits
- Model page: https://openrouter.ai/google/gemma-4-26b-a4b-it:free
- Rate limits (confirms 20 RPM / 50 RPD on <$10 lifetime spend, 1000 RPD on $10+): https://openrouter.ai/docs/api-reference/limits

## Test plan
- [x] `data.json` still parses as valid JSON
- [x] Single-field change, matches existing formatting conventions (`Text + Image + Audio + Video` pattern used elsewhere in the file)