### PR TITLE
Nightly refresh 2026-08-20: remove SambaNova, Groq and NVIDIA shutdowns, Ollama Cloud rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,13 @@ Free tier, no credit card. Ultra-fast LPU inference. [^2]
 
 Base URL: `https://api.groq.com/openai/v1`
 
-| Model Name              | Context | Max Output | Modality | Rate Limit         |
-| ----------------------- | ------- | ---------- | -------- | ------------------ |
-| llama-3.3-70b-versatile | 131K    | 32K        | Text     | 30 RPM, 1,000 RPD  |
-| llama-3.1-8b-instant    | 131K    | 131K       | Text     | 30 RPM, 14,400 RPD |
-| `openai/gpt-oss-120b`   | 131K    | 65K        | Text     | 30 RPM, 1,000 RPD  |
-| `openai/gpt-oss-20b`    | 131K    | 65K        | Text     | 30 RPM, 1,000 RPD  |
-| `groq/compound`         | 131K    | 8K         | Text     | 30 RPM, 250 RPD    |
-| `groq/compound-mini`    | 131K    | 8K         | Text     | 30 RPM, 250 RPD    |
-| `qwen/qwen3.6-27b`      | 131K    | 16K        | Text     | 30 RPM, 1,000 RPD  |
+| Model Name            | Context | Max Output | Modality | Rate Limit        |
+| --------------------- | ------- | ---------- | -------- | ----------------- |
+| `openai/gpt-oss-120b` | 131K    | 65K        | Text     | 30 RPM, 1,000 RPD |
+| `openai/gpt-oss-20b`  | 131K    | 65K        | Text     | 30 RPM, 1,000 RPD |
+| `groq/compound`       | 131K    | 8K         | Text     | 30 RPM, 250 RPD   |
+| `groq/compound-mini`  | 131K    | 8K         | Text     | 30 RPM, 250 RPD   |
+| `qwen/qwen3.6-27b`    | 131K    | 16K        | Text     | 30 RPM, 1,000 RPD |
 
 ### [Hugging Face](https://huggingface.co/settings/tokens) 🇺🇸
 
@@ -157,14 +155,14 @@ $0.10/month in Inference Provider credits for free users (subject to change). Ro
 
 Base URL: `https://router.huggingface.co/v1`
 
-| Model Name                      | Context | Max Output | Modality                       | Rate Limit              |
-| ------------------------------- | ------- | ---------- | ------------------------------ | ----------------------- |
-| Meta-Llama-3.1-8B-Instruct      | 128K    | ~4K        | Text                           | Credit-metered          |
-| gemma-3-4b-it                   | 131K    | ~4K        | Text                           | Credit-metered          |
-| phi-4                           | 16K     | ~4K        | Text                           | Credit-metered          |
-| Qwen2.5-Coder-7B-Instruct       | 131K    | ~4K        | Text                           | Credit-metered          |
-| Qwen2.5-7B-Instruct             | 131K    | ~4K        | Text                           | Credit-metered          |
-| + thousands of community models | Varies  | Varies     | Text, Image, Audio, Embeddings | 100K credits/month free |
+| Model Name                      | Context | Max Output | Modality                       | Rate Limit     |
+| ------------------------------- | ------- | ---------- | ------------------------------ | -------------- |
+| Meta-Llama-3.1-8B-Instruct      | 128K    | ~4K        | Text                           | Credit-metered |
+| gemma-3-4b-it                   | 131K    | ~4K        | Text                           | Credit-metered |
+| phi-4                           | 16K     | ~4K        | Text                           | Credit-metered |
+| Qwen2.5-Coder-7B-Instruct       | 131K    | ~4K        | Text                           | Credit-metered |
+| Qwen2.5-7B-Instruct             | 131K    | ~4K        | Text                           | Credit-metered |
+| + thousands of community models | Varies  | Varies     | Text, Image, Audio, Embeddings | Credit-metered |
 
 ### [Kilo Code](https://kilo.ai) 🇺🇸
 
@@ -210,50 +208,50 @@ Base URL: `https://api-inference.modelscope.cn/v1`
 
 ### [NVIDIA NIM](https://build.nvidia.com/explore/discover) 🇺🇸
 
-Free with NVIDIA Developer Program membership. 100+ models. Rate-limited (no daily token cap).
+Free with NVIDIA Developer Program membership. 100+ models. Rate-limited per model.
 
 Base URL: `https://integrate.api.nvidia.com/v1`
 
-| Model Name                                | Context | Max Output | Modality                               | Rate Limit |
-| ----------------------------------------- | ------- | ---------- | -------------------------------------- | ---------- |
-| `deepseek-ai/deepseek-v4-flash`           | 1M      | ~64K       | Text                                   | ~40 RPM    |
-| `nvidia/nemotron-3-super-120b-a12b`       | 262K    | 262K       | Text                                   | ~40 RPM    |
-| `nvidia/nemotron-3-nano-30b-a3b`          | 128K    | 32K        | Text                                   | ~40 RPM    |
-| `nvidia/llama-3.1-nemotron-ultra-253b-v1` | 128K    | 4K         | Text                                   | ~40 RPM    |
-| `meta/llama-3.3-70b-instruct`             | 128K    | 4K         | Text                                   | ~40 RPM    |
-| `mistralai/mistral-nemotron`              | 128K    | 8K         | Text                                   | ~40 RPM    |
-| `google/gemma-4-31b-it`                   | 128K    | 8K         | Text                                   | ~40 RPM    |
-| `mistralai/mistral-large-2-instruct`      | 128K    | 4K         | Text                                   | ~40 RPM    |
-| `minimaxai/minimax-m3`                    | 1M      | ~64K       | Text                                   | ~40 RPM    |
-| `mistralai/mistral-medium-3.5-128b`       | 262K    | 262K       | Text                                   | ~40 RPM    |
-| `nvidia/nemotron-3-ultra-550b-a55b`       | 262K    | 262K       | Text                                   | ~40 RPM    |
-| `openai/gpt-oss-120b`                     | 131K    | 131K       | Text                                   | ~40 RPM    |
-| `openai/gpt-oss-20b`                      | 131K    | 131K       | Text                                   | ~40 RPM    |
-| `deepseek-ai/deepseek-v4-pro`             | 128K    | ~64K       | Text                                   | ~40 RPM    |
-| + 85 more models                          | Varies  | Varies     | Text, Image, Video, Speech, Embeddings | ~40 RPM    |
+| Model Name                                | Context | Max Output | Modality                               | Rate Limit         |
+| ----------------------------------------- | ------- | ---------- | -------------------------------------- | ------------------ |
+| `deepseek-ai/deepseek-v4-flash`           | 1M      | ~64K       | Text                                   | 40 RPM, 10,000 RPD |
+| `nvidia/nemotron-3-super-120b-a12b`       | 1M      | 262K       | Text                                   | 40 RPM, 10,000 RPD |
+| `nvidia/nemotron-3-nano-30b-a3b`          | 262K    | 32K        | Text                                   | 40 RPM, 10,000 RPD |
+| `nvidia/llama-3.1-nemotron-ultra-253b-v1` | 128K    | 4K         | Text                                   | 40 RPM, 10,000 RPD |
+| `meta/llama-3.3-70b-instruct`             | 128K    | 4K         | Text                                   | 40 RPM, 10,000 RPD |
+| `mistralai/mistral-nemotron`              | 128K    | 8K         | Text                                   | 40 RPM, 10,000 RPD |
+| `google/gemma-4-31b-it`                   | 262K    | 8K         | Text                                   | 40 RPM, 10,000 RPD |
+| `mistralai/mistral-large-2-instruct`      | 128K    | 4K         | Text                                   | 40 RPM, 10,000 RPD |
+| `minimaxai/minimax-m3`                    | 1M      | ~64K       | Text                                   | 40 RPM, 10,000 RPD |
+| `mistralai/mistral-medium-3.5-128b`       | 262K    | 262K       | Text                                   | 40 RPM, 10,000 RPD |
+| `nvidia/nemotron-3-ultra-550b-a55b`       | 1M      | 262K       | Text                                   | 40 RPM, 10,000 RPD |
+| `openai/gpt-oss-120b`                     | 131K    | 131K       | Text                                   | 40 RPM, 10,000 RPD |
+| `openai/gpt-oss-20b`                      | 131K    | 131K       | Text                                   | 40 RPM, 10,000 RPD |
+| `deepseek-ai/deepseek-v4-pro`             | 128K    | ~64K       | Text                                   | 40 RPM, 10,000 RPD |
+| + 85 more models                          | Varies  | Varies     | Text, Image, Video, Speech, Embeddings | 40 RPM, 10,000 RPD |
 
 ### [Ollama Cloud](https://ollama.com/settings/keys) 🇺🇸
 
-Free tier with qualitative usage limits. 400+ models from Ollama library. Not OpenAI SDK-compatible; uses [Ollama API](https://docs.ollama.com/cloud). [^3]
+Free tier with usage limits. 16 cloud model families from the Ollama library. OpenAI SDK-compatible via https://ollama.com/v1. [^3]
 
-Base URL: `https://api.ollama.com`
+Base URL: `https://ollama.com/api`
 
 | Model Name             | Context | Max Output      | Modality | Rate Limit                          |
 | ---------------------- | ------- | --------------- | -------- | ----------------------------------- |
-| deepseek-v4-pro        | 128K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
+| deepseek-v4-pro        | 1M      | Model-dependent | Text     | Session/weekly limits (unpublished) |
 | deepseek-v4-flash      | 1M      | Model-dependent | Text     | Session/weekly limits (unpublished) |
-| minimax-m3             | 1M      | Model-dependent | Text     | Session/weekly limits (unpublished) |
-| kimi-k3                | 128K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
+| minimax-m3             | 512K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
+| kimi-k3                | 1M      | Model-dependent | Text     | Session/weekly limits (unpublished) |
 | `gpt-oss:120b`         | 128K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
 | `gpt-oss:20b`          | 131K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
 | nemotron-3-ultra       | 262K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
-| `mistral-large-3:675b` | 128K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
-| `qwen3.5:397b`         | 131K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
-| + 10 more cloud models | Varies  | Varies          | Text     | Session/weekly limits (unpublished) |
+| `mistral-large-3:675b` | 256K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
+| `qwen3.5:397b`         | 256K    | Model-dependent | Text     | Session/weekly limits (unpublished) |
+| + 7 more cloud models  | Varies  | Varies          | Text     | Session/weekly limits (unpublished) |
 
 ### [OpenRouter](https://openrouter.ai/keys) 🇺🇸
 
-~22 free models (marked with `:free` suffix). OpenAI SDK-compatible. [^4]
+17 free models (marked with `:free` suffix). OpenAI SDK-compatible. [^4]
 
 Base URL: `https://openrouter.ai/api/v1`
 
@@ -293,21 +291,6 @@ Base URL: `https://oai.endpoints.kepler.ai.cloud.ovh.net/v1`
 | Mistral-Nemo-Instruct-2407     | 128K    | ~4K        | Text          | 2 RPM (anonymous) |
 | Mistral-7B-Instruct-v0.3       | 32K     | ~4K        | Text          | 2 RPM (anonymous) |
 
-### [SambaNova](https://cloud.sambanova.ai/apis) 🇺🇸
-
-Free tier, no credit card. Ultra-fast RDU inference. 20 RPM, 200K tokens/day. [^8]
-
-Base URL: `https://api.sambanova.ai/v1`
-
-| Model Name                  | Context | Max Output | Modality             | Rate Limit               |
-| --------------------------- | ------- | ---------- | -------------------- | ------------------------ |
-| DeepSeek-V3.1               | 128K    | ~8K        | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| DeepSeek-V3.2 (Preview)     | 128K    | ~8K        | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| Meta-Llama-3.3-70B-Instruct | 128K    | ~3K        | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| gpt-oss-120b                | 128K    | ~128K      | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| MiniMax-M2.7                | 128K    | ~192K      | Text                 | 20 RPM, 20 RPD, 200K TPD |
-| gemma-4-31B-it (Preview)    | 128K    | ~128K      | Text + Image + Video | 20 RPM, 20 RPD, 200K TPD |
-
 ### [SiliconFlow](https://cloud.siliconflow.cn/account/ak) 🇨🇳
 
 Permanently free models, no credit card required. Identity verification required. 200+ paid models also available. [^9]
@@ -334,13 +317,12 @@ Base URL: `https://api.siliconflow.cn/v1`
 Know a free tier that's missing? [Open a PR](contributing.md). Include the provider, endpoint, rate limits (link to their docs), and a few notable models. Trial credits and time-limited promos don't count.
 
 [^1]: The Gemini API free tier is now available in the EU, UK, and Switzerland; the [available regions](https://ai.google.dev/gemini-api/docs/available-regions) page lists these regions. Google no longer publishes per-model free-tier rate limits; check your quotas in [AI Studio](https://aistudio.google.com/). Free-tier prompts may be used by Google to improve products.
-[^2]: Groq rate limits were reduced in 2026. Most models now get 1,000 RPD on the free tier (down from 14,400). Llama 4 Maverick has been deprecated. See [rate limits](https://console.groq.com/docs/rate-limits).
-[^3]: Ollama Cloud measures usage by GPU time, not tokens or requests. Free tier described as "light usage" with session limits resetting every 5 hours and weekly limits every 7 days. Pro (50x more) and Max (250x more) plans available. Not OpenAI SDK-compatible; uses the Ollama API.
+[^2]: Groq shut down llama-3.3-70b-versatile and llama-3.1-8b-instant on August 16, 2026 ([deprecations](https://console.groq.com/docs/deprecations)). Remaining free-plan limits vary by model: compound and compound-mini get 250 RPD, most others 1,000 RPD ([rate limits](https://console.groq.com/docs/rate-limits)).
+[^3]: Ollama Cloud measures usage by input, cached input, and output tokens weighted per model ([FAQ](https://docs.ollama.com/cloud)). Free tier has session limits resetting every 5 hours and weekly limits resetting every 7 days. Cloud models are also served through Ollama's OpenAI-compatible endpoint at ollama.com/v1.
 [^4]: Free models default to 50 RPD per model. A one-time purchase of $10+ in credits unlocks 1,000 RPD for free models. OpenRouter also offers a [Free Models Router](https://openrouter.ai/docs/guides/routing/routers/free-models-router) (`openrouter/free`) and [model fallbacks](https://openrouter.ai/docs/guides/routing/model-fallbacks) for chaining models in priority order. Free providers may log prompts for training.
 [^5]: Kilo Code's free pool changes frequently, and the /api/gateway/models catalog can lag what is actually served: probe results on 2026-08-19 confirmed models absent from the catalog still answering. All listed rows were verified with live requests on that date. The kilo-auto/free router picks a model from the free pool, and Kilo's docs warn it "may route your requests to providers that log prompts and outputs".
 [^6]: API-Inference is free for registered users. Current published limits are 2,000 requests/day per user (total across models), with per-model daily quotas dynamically adjusted and capped at 500; concurrency is also dynamically rate-limited. Requires Alibaba Cloud account binding and real-name verification ([limits](https://modelscope.cn/docs/model-service/API-Inference/limits), [intro](https://modelscope.cn/docs/model-service/API-Inference/intro)).
 [^7]: OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers.
-[^8]: SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible.
 [^9]: SiliconFlow requires real-name identity verification to use free models (effective May 15, 2026, per the [release notes](https://api-docs.siliconflow.cn/docs/release-notes/overview)). Verification supports mainland-Chinese documents; international users must contact support.
 [^10]: LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title.
 [^11]: The 10,000 free Neurons are shared across all Workers AI usage, not per model, and all limits reset daily at 00:00 UTC. Going over does not bill you, the request fails. Five models are excluded from Workers Free billing and need the Workers Paid plan or prepaid AI Gateway credits: `@cf/moonshotai/kimi-k2.6`, `@cf/moonshotai/kimi-k2.7-code`, `@cf/zai-org/glm-5.2`, `@cf/deepseek-ai/deepseek-v4-flash-0731`, `@cf/deepseek-ai/deepseek-v4-pro-0813` ([pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/)).

--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ Base URL: `https://integrate.api.nvidia.com/v1`
 
 | Model Name                                | Context | Max Output | Modality                               | Rate Limit         |
 | ----------------------------------------- | ------- | ---------- | -------------------------------------- | ------------------ |
-| `deepseek-ai/deepseek-v4-flash`           | 1M      | ~64K       | Text                                   | 40 RPM, 10,000 RPD |
 | `nvidia/nemotron-3-super-120b-a12b`       | 1M      | 262K       | Text                                   | 40 RPM, 10,000 RPD |
 | `nvidia/nemotron-3-nano-30b-a3b`          | 262K    | 32K        | Text                                   | 40 RPM, 10,000 RPD |
 | `nvidia/llama-3.1-nemotron-ultra-253b-v1` | 128K    | 4K         | Text                                   | 40 RPM, 10,000 RPD |
@@ -223,12 +222,10 @@ Base URL: `https://integrate.api.nvidia.com/v1`
 | `google/gemma-4-31b-it`                   | 262K    | 8K         | Text                                   | 40 RPM, 10,000 RPD |
 | `mistralai/mistral-large-2-instruct`      | 128K    | 4K         | Text                                   | 40 RPM, 10,000 RPD |
 | `minimaxai/minimax-m3`                    | 1M      | ~64K       | Text                                   | 40 RPM, 10,000 RPD |
-| `mistralai/mistral-medium-3.5-128b`       | 262K    | 262K       | Text                                   | 40 RPM, 10,000 RPD |
 | `nvidia/nemotron-3-ultra-550b-a55b`       | 1M      | 262K       | Text                                   | 40 RPM, 10,000 RPD |
 | `openai/gpt-oss-120b`                     | 131K    | 131K       | Text                                   | 40 RPM, 10,000 RPD |
 | `openai/gpt-oss-20b`                      | 131K    | 131K       | Text                                   | 40 RPM, 10,000 RPD |
-| `deepseek-ai/deepseek-v4-pro`             | 128K    | ~64K       | Text                                   | 40 RPM, 10,000 RPD |
-| + 85 more models                          | Varies  | Varies     | Text, Image, Video, Speech, Embeddings | 40 RPM, 10,000 RPD |
+| + 92 more models                          | Varies  | Varies     | Text, Image, Video, Speech, Embeddings | 40 RPM, 10,000 RPD |
 
 ### [Ollama Cloud](https://ollama.com/settings/keys) 🇺🇸
 
@@ -268,7 +265,7 @@ Base URL: `https://openrouter.ai/api/v1`
 | `nvidia/nemotron-nano-12b-v2-vl:free`    | 128K    | 128K       | Text + Image | 20 RPM, 50 RPD |
 | `poolside/laguna-s-2.1:free`             | 262K    | 32K        | Text (code)  | 20 RPM, 50 RPD |
 | `poolside/laguna-xs-2.1:free`            | 262K    | 32K        | Text (code)  | 20 RPM, 50 RPD |
-| + ~12 more free models                   | Varies  | Varies     | Text / Image | 20 RPM, 50 RPD |
+| + 6 more free models                     | Varies  | Varies     | Text / Image | 20 RPM, 50 RPD |
 
 ### [OVHcloud AI Endpoints](https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/) 🇫🇷
 

--- a/data.json
+++ b/data.json
@@ -672,14 +672,6 @@
       "footnoteRef": null,
       "models": [
         {
-          "id": "deepseek-ai/deepseek-v4-flash",
-          "name": "deepseek-ai/deepseek-v4-flash",
-          "context": "1M",
-          "maxOutput": "~64K",
-          "modality": "Text",
-          "rateLimit": "40 RPM, 10,000 RPD"
-        },
-        {
           "id": "nvidia/nemotron-3-super-120b-a12b",
           "name": "nvidia/nemotron-3-super-120b-a12b",
           "context": "1M",
@@ -744,14 +736,6 @@
           "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
-          "id": "mistralai/mistral-medium-3.5-128b",
-          "name": "mistralai/mistral-medium-3.5-128b",
-          "context": "262K",
-          "maxOutput": "262K",
-          "modality": "Text",
-          "rateLimit": "40 RPM, 10,000 RPD"
-        },
-        {
           "id": "nvidia/nemotron-3-ultra-550b-a55b",
           "name": "nvidia/nemotron-3-ultra-550b-a55b",
           "context": "1M",
@@ -776,16 +760,8 @@
           "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
-          "id": "deepseek-ai/deepseek-v4-pro",
-          "name": "deepseek-ai/deepseek-v4-pro",
-          "context": "128K",
-          "maxOutput": "~64K",
-          "modality": "Text",
-          "rateLimit": "40 RPM, 10,000 RPD"
-        },
-        {
           "id": null,
-          "name": "+ 85 more models",
+          "name": "+ 92 more models",
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text, Image, Video, Speech, Embeddings",
@@ -985,7 +961,7 @@
         },
         {
           "id": null,
-          "name": "+ ~12 more free models",
+          "name": "+ 6 more free models",
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text / Image",

--- a/data.json
+++ b/data.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-08-19",
+  "lastUpdated": "2026-08-20",
   "providers": [
     {
       "name": "Aion Labs",
@@ -404,22 +404,6 @@
       "footnoteRef": 2,
       "models": [
         {
-          "id": "llama-3.3-70b-versatile",
-          "name": "llama-3.3-70b-versatile",
-          "context": "131K",
-          "maxOutput": "32K",
-          "modality": "Text",
-          "rateLimit": "30 RPM, 1,000 RPD"
-        },
-        {
-          "id": "llama-3.1-8b-instant",
-          "name": "llama-3.1-8b-instant",
-          "context": "131K",
-          "maxOutput": "131K",
-          "modality": "Text",
-          "rateLimit": "30 RPM, 14,400 RPD"
-        },
-        {
           "id": "openai/gpt-oss-120b",
           "name": "openai/gpt-oss-120b",
           "context": "131K",
@@ -517,7 +501,7 @@
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text, Image, Audio, Embeddings",
-          "rateLimit": "100K credits/month free"
+          "rateLimit": "Credit-metered"
         }
       ]
     },
@@ -684,7 +668,7 @@
       "flag": "🇺🇸",
       "url": "https://build.nvidia.com/explore/discover",
       "baseUrl": "https://integrate.api.nvidia.com/v1",
-      "description": "Free with NVIDIA Developer Program membership. 100+ models. Rate-limited (no daily token cap).",
+      "description": "Free with NVIDIA Developer Program membership. 100+ models. Rate-limited per model.",
       "footnoteRef": null,
       "models": [
         {
@@ -693,23 +677,23 @@
           "context": "1M",
           "maxOutput": "~64K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b",
           "name": "nvidia/nemotron-3-super-120b-a12b",
-          "context": "262K",
+          "context": "1M",
           "maxOutput": "262K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "nvidia/nemotron-3-nano-30b-a3b",
           "name": "nvidia/nemotron-3-nano-30b-a3b",
-          "context": "128K",
+          "context": "262K",
           "maxOutput": "32K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
@@ -717,7 +701,7 @@
           "context": "128K",
           "maxOutput": "4K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "meta/llama-3.3-70b-instruct",
@@ -725,7 +709,7 @@
           "context": "128K",
           "maxOutput": "4K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "mistralai/mistral-nemotron",
@@ -733,15 +717,15 @@
           "context": "128K",
           "maxOutput": "8K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "google/gemma-4-31b-it",
           "name": "google/gemma-4-31b-it",
-          "context": "128K",
+          "context": "262K",
           "maxOutput": "8K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "mistralai/mistral-large-2-instruct",
@@ -749,7 +733,7 @@
           "context": "128K",
           "maxOutput": "4K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "minimaxai/minimax-m3",
@@ -757,7 +741,7 @@
           "context": "1M",
           "maxOutput": "~64K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "mistralai/mistral-medium-3.5-128b",
@@ -765,15 +749,15 @@
           "context": "262K",
           "maxOutput": "262K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "nvidia/nemotron-3-ultra-550b-a55b",
           "name": "nvidia/nemotron-3-ultra-550b-a55b",
-          "context": "262K",
+          "context": "1M",
           "maxOutput": "262K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "openai/gpt-oss-120b",
@@ -781,7 +765,7 @@
           "context": "131K",
           "maxOutput": "131K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "openai/gpt-oss-20b",
@@ -789,7 +773,7 @@
           "context": "131K",
           "maxOutput": "131K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": "deepseek-ai/deepseek-v4-pro",
@@ -797,7 +781,7 @@
           "context": "128K",
           "maxOutput": "~64K",
           "modality": "Text",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         },
         {
           "id": null,
@@ -805,7 +789,7 @@
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text, Image, Video, Speech, Embeddings",
-          "rateLimit": "~40 RPM"
+          "rateLimit": "40 RPM, 10,000 RPD"
         }
       ]
     },
@@ -815,14 +799,14 @@
       "country": "US",
       "flag": "🇺🇸",
       "url": "https://ollama.com/settings/keys",
-      "baseUrl": "https://api.ollama.com",
-      "description": "Free tier with qualitative usage limits. 400+ models from Ollama library. Not OpenAI SDK-compatible; uses [Ollama API](https://docs.ollama.com/cloud).",
+      "baseUrl": "https://ollama.com/api",
+      "description": "Free tier with usage limits. 16 cloud model families from the Ollama library. OpenAI SDK-compatible via https://ollama.com/v1.",
       "footnoteRef": 3,
       "models": [
         {
           "id": "deepseek-v4-pro",
           "name": "deepseek-v4-pro",
-          "context": "128K",
+          "context": "1M",
           "maxOutput": "Model-dependent",
           "modality": "Text",
           "rateLimit": "Session/weekly limits (unpublished)"
@@ -838,7 +822,7 @@
         {
           "id": "minimax-m3",
           "name": "minimax-m3",
-          "context": "1M",
+          "context": "512K",
           "maxOutput": "Model-dependent",
           "modality": "Text",
           "rateLimit": "Session/weekly limits (unpublished)"
@@ -846,7 +830,7 @@
         {
           "id": "kimi-k3",
           "name": "kimi-k3",
-          "context": "128K",
+          "context": "1M",
           "maxOutput": "Model-dependent",
           "modality": "Text",
           "rateLimit": "Session/weekly limits (unpublished)"
@@ -878,7 +862,7 @@
         {
           "id": "mistral-large-3:675b",
           "name": "mistral-large-3:675b",
-          "context": "128K",
+          "context": "256K",
           "maxOutput": "Model-dependent",
           "modality": "Text",
           "rateLimit": "Session/weekly limits (unpublished)"
@@ -886,14 +870,14 @@
         {
           "id": "qwen3.5:397b",
           "name": "qwen3.5:397b",
-          "context": "131K",
+          "context": "256K",
           "maxOutput": "Model-dependent",
           "modality": "Text",
           "rateLimit": "Session/weekly limits (unpublished)"
         },
         {
           "id": null,
-          "name": "+ 10 more cloud models",
+          "name": "+ 7 more cloud models",
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text",
@@ -908,7 +892,7 @@
       "flag": "🇺🇸",
       "url": "https://openrouter.ai/keys",
       "baseUrl": "https://openrouter.ai/api/v1",
-      "description": "~22 free models (marked with `:free` suffix). OpenAI SDK-compatible.",
+      "description": "17 free models (marked with `:free` suffix). OpenAI SDK-compatible.",
       "footnoteRef": 4,
       "models": [
         {
@@ -1118,66 +1102,6 @@
       ]
     },
     {
-      "name": "SambaNova",
-      "category": "inference_provider",
-      "country": "US",
-      "flag": "🇺🇸",
-      "url": "https://cloud.sambanova.ai/apis",
-      "baseUrl": "https://api.sambanova.ai/v1",
-      "description": "Free tier, no credit card. Ultra-fast RDU inference. 20 RPM, 200K tokens/day.",
-      "footnoteRef": 8,
-      "models": [
-        {
-          "id": "DeepSeek-V3.1",
-          "name": "DeepSeek-V3.1",
-          "context": "128K",
-          "maxOutput": "~8K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
-        {
-          "id": "DeepSeek-V3.2",
-          "name": "DeepSeek-V3.2 (Preview)",
-          "context": "128K",
-          "maxOutput": "~8K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
-        {
-          "id": "Meta-Llama-3.3-70B-Instruct",
-          "name": "Meta-Llama-3.3-70B-Instruct",
-          "context": "128K",
-          "maxOutput": "~3K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
-        {
-          "id": "gpt-oss-120b",
-          "name": "gpt-oss-120b",
-          "context": "128K",
-          "maxOutput": "~128K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
-        {
-          "id": "MiniMax-M2.7",
-          "name": "MiniMax-M2.7",
-          "context": "128K",
-          "maxOutput": "~192K",
-          "modality": "Text",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        },
-        {
-          "id": "gemma-4-31B-it",
-          "name": "gemma-4-31B-it (Preview)",
-          "context": "128K",
-          "maxOutput": "~128K",
-          "modality": "Text + Image + Video",
-          "rateLimit": "20 RPM, 20 RPD, 200K TPD"
-        }
-      ]
-    },
-    {
       "name": "SiliconFlow",
       "category": "inference_provider",
       "country": "CN",
@@ -1213,11 +1137,11 @@
     },
     {
       "id": 2,
-      "text": "Groq rate limits were reduced in 2026. Most models now get 1,000 RPD on the free tier (down from 14,400). Llama 4 Maverick has been deprecated. See [rate limits](https://console.groq.com/docs/rate-limits)."
+      "text": "Groq shut down llama-3.3-70b-versatile and llama-3.1-8b-instant on August 16, 2026 ([deprecations](https://console.groq.com/docs/deprecations)). Remaining free-plan limits vary by model: compound and compound-mini get 250 RPD, most others 1,000 RPD ([rate limits](https://console.groq.com/docs/rate-limits))."
     },
     {
       "id": 3,
-      "text": "Ollama Cloud measures usage by GPU time, not tokens or requests. Free tier described as \"light usage\" with session limits resetting every 5 hours and weekly limits every 7 days. Pro (50x more) and Max (250x more) plans available. Not OpenAI SDK-compatible; uses the Ollama API."
+      "text": "Ollama Cloud measures usage by input, cached input, and output tokens weighted per model ([FAQ](https://docs.ollama.com/cloud)). Free tier has session limits resetting every 5 hours and weekly limits resetting every 7 days. Cloud models are also served through Ollama's OpenAI-compatible endpoint at ollama.com/v1."
     },
     {
       "id": 4,
@@ -1234,10 +1158,6 @@
     {
       "id": 7,
       "text": "OVHcloud AI Endpoints offers a permanent free anonymous tier (2 requests per minute per IP, per model) with no signup or API key required. Higher rate limits (400 RPM per Public Cloud project per model) require an API key and are billed pay-as-you-go per token; new Public Cloud accounts get up to $200 in free trial credits. Models are hosted in EU data centers."
-    },
-    {
-      "id": 8,
-      "text": "SambaNova grants $5 in initial credits (valid 30 days) on top of the permanent free tier. The free tier itself persists indefinitely with 20 RPM, 20 RPD, and 200K TPD per model. No credit card required. OpenAI SDK-compatible."
     },
     {
       "id": 9,


### PR DESCRIPTION
Nightly refresh, 2026-08-20.

## Removed: SambaNova

The free tier is gone for new accounts. Eight live requests across two days (2026-08-19 and 2026-08-20) and two different networks all returned HTTP 402 `PAYMENT_METHOD_REQUIRED` ("A payment method is required. Add one at cloud.sambanova.ai/plans/billing", `balance_units: 0`), covering DeepSeek-V3.1, DeepSeek-V3.2, Meta-Llama-3.3-70B-Instruct, gpt-oss-120b, gemma-4-31B-it, and MiniMax-M2.7. The [pricing page](https://cloud.sambanova.ai/plans/pricing) shows per-token pricing for exactly these six models and no free plan anywhere on the page. Their rate-limits doc still describes a free tier; live behavior over two days takes precedence, and the doc lag is on record. @mgiganto called it in #95, thanks.

## Groq: two models shut down

Groq retired llama-3.3-70b-versatile and llama-3.1-8b-instant on August 16, 2026, per the official [deprecations page](https://console.groq.com/docs/deprecations); both are gone from the Free Plan limits table. Rows removed, footnote 2 rewritten around the shutdown. The remaining five rows match the current [rate limits](https://console.groq.com/docs/rate-limits) exactly.

## NVIDIA NIM: three models deprecated, limits now published

deepseek-v4-pro, deepseek-v4-flash, and mistral-medium-3.5-128b carry official "deprecated on 08/07/2026" notices and are absent from the live catalog (103 ids, checked 2026-08-20). Rows removed. NVIDIA now publishes "Up to 40 rpm" plus "10,000 requests per day" on every model page: rate-limit column updated. Four context windows raised to match current model pages (nemotron-3-super and nemotron-3-ultra to 1M, nemotron-3-nano and gemma-4-31b-it to 262K).

## Ollama Cloud: usage model and compatibility changed

The [FAQ](https://docs.ollama.com/cloud) now measures usage by input, cached input, and output tokens weighted per model; the old GPU-time wording is gone. Cloud models are served through Ollama's OpenAI-compatible endpoint (ollama.com/v1), so the "Not OpenAI SDK-compatible" note was outdated. Base URL updated to the documented `https://ollama.com/api` ([authentication](https://docs.ollama.com/api/authentication)); a keyless POST to that endpoint returns 401 Unauthorized, confirming it is live and auth-gated (probe recorded 2026-08-20). Catalog is 16 cloud model families, not "400+". Five context windows corrected. Footnote 3 rewritten.

## Smaller fixes

- Hugging Face: the "+ thousands of community models" row cited "100K credits/month free", which matches nothing in the current pricing docs; now "Credit-metered".
- OpenRouter: the live public catalog holds 17 `:free` models; description updated from "~22".

## Not in this PR (pending verification)

- Additions blocked on keys: 6 new OpenRouter `:free` models (including z-ai/glm-5.2:free), Groq's gpt-oss-safeguard-20b, NVIDIA's deepseek-v4-flash-0731.
- OpenRouter inclusionai/ling-3.0-flash:free is absent from the live catalog but has no second proof yet; flagged, not removed.
- Hugging Face Qwen/Qwen2.5-7B-Instruct: absent from the router catalog, still mapped on the Hub; in observation.
- NVIDIA mistral-large-2-instruct: serves in the catalog, build page 404s; in observation.
