### PR TITLE
feat: nightly refresh 2026-08-21

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-08-20",
+  "lastUpdated": "2026-08-21",
   "providers": [
     {
       "name": "Aion Labs",
@@ -16,7 +16,7 @@
           "name": "aion-labs/aion-2.0",
           "context": "128K",
           "maxOutput": "32K",
-          "modality": "Text (roleplay)",
+          "modality": "Text (reasoning)",
           "rateLimit": "15 RPM, 20K TPD"
         },
         {
@@ -24,7 +24,7 @@
           "name": "aion-labs/aion-rp-llama-3.1-8b",
           "context": "32K",
           "maxOutput": "32K",
-          "modality": "Text (roleplay)",
+          "modality": "Text",
           "rateLimit": "15 RPM, 20K TPD"
         },
         {
@@ -32,7 +32,7 @@
           "name": "aion-labs/aion-3.0",
           "context": "128K",
           "maxOutput": "32K",
-          "modality": "Text (roleplay, reasoning)",
+          "modality": "Text (reasoning)",
           "rateLimit": "15 RPM, 20K TPD"
         },
         {
@@ -40,7 +40,7 @@
           "name": "aion-labs/aion-3.0-mini",
           "context": "128K",
           "maxOutput": "32K",
-          "modality": "Text (roleplay, reasoning)",
+          "modality": "Text (reasoning)",
           "rateLimit": "15 RPM, 20K TPD"
         }
       ]
@@ -156,6 +156,14 @@
       "footnoteRef": 1,
       "models": [
         {
+          "id": "gemini-3.7-flash",
+          "name": "Gemini 3.7 Flash",
+          "context": "1M",
+          "maxOutput": "65K",
+          "modality": "Text + Image + Audio + Video",
+          "rateLimit": "—"
+        },
+        {
           "id": "gemini-3.6-flash",
           "name": "Gemini 3.6 Flash",
           "context": "1M",
@@ -210,6 +218,22 @@
           "maxOutput": "65K",
           "modality": "Text + Image + Audio + Video",
           "rateLimit": "5 RPM, 50 RPD"
+        },
+        {
+          "id": "gemma-4-31b-it",
+          "name": "Gemma 4 31B",
+          "context": "256K",
+          "maxOutput": "32K",
+          "modality": "Text",
+          "rateLimit": "—"
+        },
+        {
+          "id": "gemma-4-26b-a4b-it",
+          "name": "Gemma 4 26B A4B",
+          "context": "256K",
+          "maxOutput": "32K",
+          "modality": "Text",
+          "rateLimit": "—"
         }
       ]
     },
@@ -356,7 +380,7 @@
           "name": "@cf/google/gemma-4-26b-a4b-it",
           "context": "256K",
           "maxOutput": "Shared w/ context",
-          "modality": "Text",
+          "modality": "Text + Vision",
           "rateLimit": "10K neurons/day (shared)"
         },
         {
@@ -510,9 +534,9 @@
       "category": "inference_provider",
       "country": "US",
       "flag": "🇺🇸",
-      "url": "https://kilo.ai",
+      "url": "https://app.kilo.ai/profile",
       "baseUrl": "https://api.kilo.ai/api/gateway",
-      "description": "Free models with no credit card required. `kilo-auto/free` auto-router dynamically routes to models in the free pool.",
+      "description": "Free models with no credit card and no API key required. `kilo-auto/free` auto-router dynamically routes to models in the free pool.",
       "footnoteRef": 5,
       "models": [
         {
@@ -521,15 +545,15 @@
           "context": "1M",
           "maxOutput": "65K",
           "modality": "Text",
-          "rateLimit": "~200 req/hr"
+          "rateLimit": "200 req/hr"
         },
         {
           "id": "stepfun/step-3.7-flash:free",
           "name": "stepfun/step-3.7-flash:free",
           "context": "262K",
           "maxOutput": "262K",
-          "modality": "Text",
-          "rateLimit": "~200 req/hr"
+          "modality": "Text + Vision",
+          "rateLimit": "200 req/hr"
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b:free",
@@ -537,15 +561,15 @@
           "context": "262K",
           "maxOutput": "262K",
           "modality": "Text",
-          "rateLimit": "~200 req/hr"
+          "rateLimit": "200 req/hr"
         },
         {
           "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
           "name": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
           "context": "256K",
           "maxOutput": "65K",
-          "modality": "Text (reasoning)",
-          "rateLimit": "~200 req/hr"
+          "modality": "Multimodal",
+          "rateLimit": "200 req/hr"
         },
         {
           "id": "poolside/laguna-s-2.1:free",
@@ -553,7 +577,7 @@
           "context": "262K",
           "maxOutput": "32K",
           "modality": "Text (code)",
-          "rateLimit": "~200 req/hr"
+          "rateLimit": "200 req/hr"
         },
         {
           "id": "poolside/laguna-xs-2.1:free",
@@ -561,7 +585,7 @@
           "context": "262K",
           "maxOutput": "32K",
           "modality": "Text (code)",
-          "rateLimit": "~200 req/hr"
+          "rateLimit": "200 req/hr"
         },
         {
           "id": "cohere/north-mini-code:free",
@@ -569,7 +593,7 @@
           "context": "256K",
           "maxOutput": "64K",
           "modality": "Text (code)",
-          "rateLimit": "~200 req/hr"
+          "rateLimit": "200 req/hr"
         },
         {
           "id": "openrouter/free",
@@ -577,23 +601,31 @@
           "context": "Varies",
           "maxOutput": "Varies",
           "modality": "Text",
-          "rateLimit": "~200 req/hr"
+          "rateLimit": "200 req/hr"
         },
         {
           "id": "tencent/hy3:free",
           "name": "tencent/hy3:free",
-          "context": "—",
-          "maxOutput": "—",
+          "context": "262K",
+          "maxOutput": "128K",
           "modality": "Text",
-          "rateLimit": "~200 req/hr"
+          "rateLimit": "200 req/hr"
         },
         {
           "id": "nvidia/nemotron-3.5-lightning:free",
           "name": "nvidia/nemotron-3.5-lightning:free",
-          "context": "—",
-          "maxOutput": "—",
+          "context": "1M",
+          "maxOutput": "65K",
           "modality": "Text",
-          "rateLimit": "~200 req/hr"
+          "rateLimit": "200 req/hr"
+        },
+        {
+          "id": "liquid/lfm-2.5-2.6b:free",
+          "name": "liquid/lfm-2.5-2.6b:free",
+          "context": "128K",
+          "maxOutput": "8K",
+          "modality": "Text",
+          "rateLimit": "200 req/hr"
         }
       ]
     },
@@ -604,24 +636,32 @@
       "flag": "🇬🇧",
       "url": "https://token.llm7.io",
       "baseUrl": "https://api.llm7.io/v1",
-      "description": "API gateway with a free tier. Anonymous access is now limited to select models; a free token from token.llm7.io unlocks the rest.",
+      "description": "API gateway with a free tier. Anonymous access needs no key and reaches the `turbo` models; a free token from token.llm7.io raises the rate and token limits but reaches the same models.",
       "footnoteRef": 10,
       "models": [
         {
           "id": "gpt-oss:20b",
           "name": "gpt-oss:20b",
-          "context": "—",
+          "context": "128K",
           "maxOutput": "—",
-          "modality": "Text (reasoning)",
-          "rateLimit": "30 RPM (120 with token)"
+          "modality": "Text",
+          "rateLimit": "10 RPM, 60 req/hr (anonymous)"
         },
         {
-          "id": null,
-          "name": "+ ~40 more models (token required)",
-          "context": "Varies",
-          "maxOutput": "Varies",
+          "id": "mistral-Nemo-Instruct-2407",
+          "name": "mistral-Nemo-Instruct-2407",
+          "context": "128K",
+          "maxOutput": "—",
           "modality": "Text",
-          "rateLimit": "30 RPM (120 with token)"
+          "rateLimit": "10 RPM, 60 req/hr (anonymous)"
+        },
+        {
+          "id": "minimax-m2.7",
+          "name": "minimax-m2.7",
+          "context": "180K",
+          "maxOutput": "—",
+          "modality": "Text (reasoning)",
+          "rateLimit": "10 RPM, 60 req/hr (anonymous)"
         }
       ]
     },
@@ -638,7 +678,7 @@
         {
           "id": "Qwen/Qwen3.5-35B-A3B",
           "name": "Qwen/Qwen3.5-35B-A3B",
-          "context": "—",
+          "context": "256K",
           "maxOutput": "—",
           "modality": "Text",
           "rateLimit": "2,000 RPD total; <=500 RPD/model (dynamic)"
@@ -646,7 +686,7 @@
         {
           "id": "Qwen/Qwen3.5-27B",
           "name": "Qwen/Qwen3.5-27B",
-          "context": "—",
+          "context": "256K",
           "maxOutput": "—",
           "modality": "Text",
           "rateLimit": "2,000 RPD total; <=500 RPD/model (dynamic)"
@@ -1084,24 +1124,16 @@
       "flag": "🇨🇳",
       "url": "https://cloud.siliconflow.cn/account/ak",
       "baseUrl": "https://api.siliconflow.cn/v1",
-      "description": "Permanently free models, no credit card required. Identity verification required. 200+ paid models also available.",
+      "description": "Permanently free models, no credit card required. Identity verification required. 100+ models in the catalog, most of them paid.",
       "footnoteRef": 9,
       "models": [
         {
           "id": "Qwen/Qwen3-8B",
           "name": "Qwen/Qwen3-8B",
-          "context": "131K",
-          "maxOutput": "131K",
+          "context": "128K",
+          "maxOutput": "—",
           "modality": "Text",
-          "rateLimit": "30 RPM, 60K TPM"
-        },
-        {
-          "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
-          "name": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
-          "context": "131K",
-          "maxOutput": "Configurable",
-          "modality": "Text (reasoning)",
-          "rateLimit": "30 RPM, 60K TPM"
+          "rateLimit": "1,000 RPM, 50,000 TPM"
         }
       ]
     }
@@ -1109,7 +1141,7 @@
   "footnotes": [
     {
       "id": 1,
-      "text": "The Gemini API free tier is now available in the EU, UK, and Switzerland; the [available regions](https://ai.google.dev/gemini-api/docs/available-regions) page lists these regions. Google no longer publishes per-model free-tier rate limits; check your quotas in [AI Studio](https://aistudio.google.com/). Free-tier prompts may be used by Google to improve products."
+      "text": "The Gemini API free tier is available to developers in the EU, UK, and Switzerland; the [available regions](https://ai.google.dev/gemini-api/docs/available-regions) page lists these regions. The [terms](https://ai.google.dev/gemini-api/terms) still require you to use only Paid Services when you make an API Client available to users in the European Economic Area, Switzerland, or the UK. Google no longer publishes per-model free-tier rate limits; check your quotas in [AI Studio](https://aistudio.google.com/). Free-tier prompts may be used by Google to improve products, except for users in the EEA, Switzerland and the UK, where the paid-services data terms also govern the unpaid quota, so those prompts are not used to improve Google products. `gemini-3.1-flash-lite` is on the [deprecation schedule](https://ai.google.dev/gemini-api/docs/deprecations), with a shutdown date of May 7, 2027 and `gemini-3.5-flash-lite` as its replacement; the row stays because the model is live and free today."
     },
     {
       "id": 2,
@@ -1125,7 +1157,7 @@
     },
     {
       "id": 5,
-      "text": "Kilo Code's free pool changes frequently, and the /api/gateway/models catalog can lag what is actually served: probe results on 2026-08-19 confirmed models absent from the catalog still answering. All listed rows were verified with live requests on that date. The kilo-auto/free router picks a model from the free pool, and Kilo's docs warn it \"may route your requests to providers that log prompts and outputs\"."
+      "text": "Kilo Code's free pool changes frequently, and the /api/gateway/models catalog can lag what is actually served: probe results have confirmed models absent from the catalog still answering. Every row listed here answered a live request between 2026-08-19 and 2026-08-21. Free models are reachable with no API key, at 200 requests per hour per IP ([authentication](https://kilo.ai/docs/gateway/authentication)). The kilo-auto/free router picks a model from the free pool, and Kilo's docs warn it \"may route your requests to providers that log prompts and outputs\". The NVIDIA free endpoints carry NVIDIA's own condition, quoted on Kilo's [models page](https://kilo.ai/docs/gateway/models-and-providers): \"Trial use only - do not submit personal or confidential data. Your use is logged for security purposes and to improve NVIDIA products and services.\""
     },
     {
       "id": 6,
@@ -1141,7 +1173,7 @@
     },
     {
       "id": 10,
-      "text": "LLM7.io rotated its catalog in August 2026; previously listed models now return model_unavailable, and the catalog itself changes frequently (43 models at last check). Anonymous access (no key) was confirmed on gpt-oss:20b on 2026-08-19; most other models require a token, available free from the API key page linked in the title."
+      "text": "LLM7.io rotates its catalog frequently, so the model list changes between checks. Access is tier-based, not token-based: `turbo` models are reachable anonymously or with a free token, `pro` models need the paid plan ([models API](https://docs.llm7.io/guides/models-api)). Anonymous access is capped at 1 RPS, 10 RPM, 60 requests per hour and 500,000 tokens per 24 hours; a free token raises that to 2 RPS, 40 RPM, 100 requests per hour and 1,000,000 tokens per 24 hours ([limits](https://docs.llm7.io/limits)). A paid Pro plan is available at $12/month. Anonymous access with no key was confirmed by live request on 2026-08-21."
     },
     {
       "id": 11,

--- a/data.json
+++ b/data.json
@@ -248,7 +248,7 @@
       "footnoteRef": 13,
       "models": [
         {
-          "id": "mistral-medium-2604",
+          "id": "mistral-medium-3-5",
           "name": "Mistral Medium 3.5 (128B)",
           "context": "256K",
           "maxOutput": "—",
@@ -276,7 +276,7 @@
           "name": "Ministral 3 8B",
           "context": "256K",
           "maxOutput": "—",
-          "modality": "Text",
+          "modality": "Text + Vision",
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
@@ -292,7 +292,7 @@
           "name": "Ministral 3 3B",
           "context": "256K",
           "maxOutput": "—",
-          "modality": "Text",
+          "modality": "Text + Vision",
           "rateLimit": "~1 RPS, 500K TPM"
         },
         {
@@ -300,7 +300,7 @@
           "name": "Ministral 3 14B",
           "context": "256K",
           "maxOutput": "—",
-          "modality": "Text",
+          "modality": "Text + Vision",
           "rateLimit": "~1 RPS, 500K TPM"
         }
       ]
@@ -1185,7 +1185,7 @@
     },
     {
       "id": 13,
-      "text": "Mistral plans are global: the monthly allowance is shared across Studio, the API, and Vibe Code, so CLI usage eats the same budget ([subscriptions](https://docs.mistral.ai/admin/user-management-finops/subscriptions)). Free mode is the default for new accounts and needs no credit card ([quickstart](https://docs.mistral.ai/getting-started/quickstarts/studio/activate-and-generate-api-key)). Free-mode inputs and outputs may be used to train Mistral models, and you can opt out at any time ([data usage](https://help.mistral.ai/en/articles/347617-do-you-use-my-user-data-to-train-your-artificial-intelligence-models)). Mistral no longer publishes numeric free-tier rate limits and points you at the Limits page of the admin panel instead ([rate limits](https://help.mistral.ai/en/articles/698531-why-am-i-hitting-api-rate-limits-and-how-do-i-increase-them)); the rate limit column is kept from the last published values."
+      "text": "Mistral plans are global: the monthly allowance is shared across Studio, the API, and Vibe Code, so CLI usage eats the same budget ([subscriptions](https://docs.mistral.ai/admin/billing-usage/subscriptions)). Free mode is the default for new accounts and needs no credit card ([quickstart](https://docs.mistral.ai/getting-started/quickstarts/studio/activate-and-generate-api-key)), and the Free plan card on the [pricing page](https://mistral.ai/pricing) is what carries the $10/month in API credits figure quoted in the description. Free-mode inputs and outputs may be used to train Mistral models, and you can opt out at any time ([data usage](https://help.mistral.ai/en/articles/347617-do-you-use-my-user-data-to-train-your-artificial-intelligence-models)). Mistral no longer publishes numeric free-tier rate limits and points you at the Limits page of the admin panel instead ([rate limits](https://help.mistral.ai/en/articles/698531-why-am-i-hitting-api-rate-limits-and-how-do-i-increase-them)); the rate limit column is kept from the last published values."
     }
   ],
   "glossary": [

--- a/data.json
+++ b/data.json
@@ -622,7 +622,7 @@
         {
           "id": "liquid/lfm-2.5-2.6b:free",
           "name": "liquid/lfm-2.5-2.6b:free",
-          "context": "128K",
+          "context": "64K",
           "maxOutput": "8K",
           "modality": "Text",
           "rateLimit": "200 req/hr"


### PR DESCRIPTION
## What this is

This refresh carries the work of the night of 2026-08-20, which was written but never shipped. Nothing from it was ever pushed. I re-verified all of it today before putting it back on the branch, and every probe-backed claim was probed a second time, one day after the first. On top of that it carries tonight's audits of Aion Labs, Mistral AI and Cloudflare Workers AI.

`lastUpdated` is set to 2026-08-21, the day this ships.

## Re-verification of the carried work

Nine probes, re-run today, all with the same verdict as on 2026-08-20:

| Model | 2026-08-20 | 2026-08-21 | check id |
| --- | --- | --- | --- |
| `llm7-io` `gpt-oss:20b` | confirmed_free | confirmed_free | 89 |
| `llm7-io` `mistral-Nemo-Instruct-2407` | confirmed_free | confirmed_free | 88 |
| `llm7-io` `minimax-m2.7` | confirmed_free | confirmed_free | 87 |
| `google-gemini` `gemini-3.7-flash` | confirmed_free | confirmed_free | 94 |
| `google-gemini` `gemma-4-31b-it` | confirmed_free | confirmed_free | 93 |
| `google-gemini` `gemma-4-26b-a4b-it` | confirmed_free | confirmed_free | 92 |
| `kilo-code` `liquid/lfm-2.5-2.6b:free` | confirmed_free | confirmed_free | 91 |
| `llm7-io` `gemma4:31b` (not listed) | unprobeable 401 | unprobeable 401 | 86 |
| `kilo-code` `google/gemma-4-26b-a4b-it:free` (not listed) | inconclusive 404 | dead 404 | 90 |

The last two rows are candidates I rejected on 2026-08-20. They were rejected again today on the same evidence, so they stay off the list.

There is a third probe on each new row, and it is the one that matters most. My probe script had been sending the same fixed prompt every time, and that is a weak test. Tonight I found Pollinations returning HTTP 200 out of a response cache keyed on the prompt: same `id` and same `created` timestamp across calls minutes apart. A provider that caches like that could show me 200 forever while serving nobody. `scripts/probe.sh` now puts a fresh random nonce in every prompt. I re-ran the six additions plus `gpt-oss:20b` with it, and all seven answered 200 on a prompt that had never been sent before, which is live inference and cannot be a cache hit.

| Model | nonce probe 2026-08-21 |
| --- | --- |
| `llm7-io` `gpt-oss:20b` | 98 |
| `llm7-io` `minimax-m2.7` | 99 |
| `llm7-io` `mistral-Nemo-Instruct-2407` | 100 |
| `kilo-code` `liquid/lfm-2.5-2.6b:free` | 101 |
| `google-gemini` `gemma-4-26b-a4b-it` | 102 |
| `google-gemini` `gemma-4-31b-it` | 103 |
| `google-gemini` `gemini-3.7-flash` | 104 |

Each of the six new rows is therefore confirmed on three separate probes.

## Google Gemini

Three rows added.

- `gemini-3.7-flash`, 1M context, 65K max output. Free of charge on the free tier per https://ai.google.dev/gemini-api/docs/pricing. Probed `confirmed_free`, check 80 on 2026-08-20 and check 94 on 2026-08-21. Google's own catalog reports inputTokenLimit 1048576 and outputTokenLimit 65536, which is the 1M / 65K published here.
- `gemma-4-31b-it`, 256K / 32K. Gemma 4 is free of charge on the free tier and not available on the paid tier per the same pricing page. Probed `confirmed_free`, check 81 then check 93. Catalog reports 262144 / 32768.
- `gemma-4-26b-a4b-it`, 256K / 32K, same evidence, check 82 then check 92. Catalog reports 262144 / 32768.

Both Gemma rows are labelled `Text`. Every Gemini row in this entry uses input modality labels, and none of them is tagged as reasoning even though Google flags `thinking: true` on all of them, so `Text` is what is consistent here.

Footnote 1 rewritten. Two things in it were wrong or too broad, both from https://ai.google.dev/gemini-api/terms:

- The old text said the free tier is available in the EU, UK and Switzerland. That is true for a developer, but the terms require Paid Services when you make an API Client available to users in the European Economic Area, Switzerland or the United Kingdom. The footnote now says both.
- The data-use sentence was blanket. For users in the EEA, Switzerland and the UK the paid-services data terms govern the unpaid quota, so free-tier prompts from those regions are not used to improve Google products. The footnote now carries that exception.

The footnote also now records that `gemini-3.1-flash-lite` is on the deprecation schedule with a shutdown date of May 7, 2027 and `gemini-3.5-flash-lite` as its replacement (https://ai.google.dev/gemini-api/docs/deprecations). The row stays, the model is live and free today.

## LLM7.io

The `+ ~40 more models (token required)` row is gone. It was our own claim and it is no longer true: access is tier-gated, not token-gated. https://docs.llm7.io/guides/models-api states that `turbo` models are available to anonymous and free-token users, and `pro` models to Pro subscribers and users with a topped-up balance. A free token no longer unlocks the rest of the catalog.

Two rows added, both `turbo` tier:

- `mistral-Nemo-Instruct-2407`, 128K context, `Text`. Probed `confirmed_free`, check 73 on 2026-08-20 and check 88 on 2026-08-21. The catalog at https://api.llm7.io/v1/models reports tier turbo, context_window 128000 and `"reasoning": false`.
- `minimax-m2.7`, 180K context, `Text (reasoning)`. Probed `confirmed_free`, check 74 on 2026-08-20 and check 87 on 2026-08-21. The same catalog reports tier turbo, context_window 180000 and `"reasoning": true`, and today's probe came back with visible chain of thought in the content. This is LLM7's own `minimax-m2.7` id. It is not related to the SambaNova MiniMax-M2.7 rows, which returned 402.

`gpt-oss:20b` corrected on three fields. Context `—` to `128K` and modality `Text (reasoning)` to `Text`, both from https://api.llm7.io/v1/models, which reports context_window 128000 and `"reasoning": false` for that id. Rate limit `30 RPM (120 with token)` to `10 RPM, 60 req/hr (anonymous)`, from https://docs.llm7.io/limits: anonymous is 1 RPS, 10 RPM and 60 requests per hour. The two new rows carry the same value so the column reads the same way.

I used the catalog's `reasoning` field to demote `gpt-oss:20b`, so I used it to promote `minimax-m2.7` as well. Using it in one direction only would have been the defect.

Description rewritten to say what actually gates access: anonymous access needs no key and reaches the `turbo` models, and a free token raises the rate and token limits but reaches the same models.

Footnote 10 rewritten around the tiers and the published caps, with no hard catalog count since the catalog rotates. Anonymous is capped at 1 RPS, 10 RPM, 60 requests per hour and 500,000 tokens per 24 hours. A free token raises that to 2 RPS, 40 RPM, 100 requests per hour and 1,000,000 tokens per 24 hours. Sources https://docs.llm7.io/limits and https://docs.llm7.io/guides/models-api. The keyless confirmation date in the footnote is 2026-08-21, check 89.

## Kilo Code

The entry title now links https://app.kilo.ai/profile instead of the homepage. The key lives on the profile page per https://kilo.ai/docs/getting-started/setup-authentication, and the convention here is to link the API key page.

Description now says no credit card and no API key required. https://kilo.ai/docs/gateway/authentication states that the gateway allows unauthenticated access for free models, identified by IP and rate limited at 200 requests per hour per IP.

Every rate limit went from `~200 req/hr` to `200 req/hr`. The figure is exact and documented at https://kilo.ai/docs/gateway/usage-and-billing, which publishes 200 requests per hour per IP for free models. The tilde was never justified.

Field corrections, all from the gateway catalog at https://api.kilo.ai/api/gateway/models:

- `tencent/hy3:free`: context `—` to `262K`, max output `—` to `128K` (context_length 262144, max_completion_tokens 128000).
- `nvidia/nemotron-3.5-lightning:free`: context `—` to `1M`, max output `—` to `65K` (context_length 1000000, max_completion_tokens 65536).
- `stepfun/step-3.7-flash:free`: modality `Text` to `Text + Vision` (`"modality": "text+image->text"`).
- `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`: modality `Text (reasoning)` to `Multimodal` (`"modality": "text+image+audio+video->text"`).

One row added: `liquid/lfm-2.5-2.6b:free`, 64K / 8K, `Text`. Probed `confirmed_free`, check 76 on 2026-08-20 and check 91 on 2026-08-21. The catalog record has context_length 65536, max_completion_tokens 8192, isFree true and expiration_date null. The carried change set had this row at 128K, which no Kilo page supports. It is 64K.

Footnote 5 keeps the catalog-lag warning and the prompt-logging warning, both re-read at https://kilo.ai/docs/gateway/models-and-providers, and adds two documented conditions: free models are reachable with no API key at 200 requests per hour per IP, and the NVIDIA free endpoints carry NVIDIA's own condition, quoted on Kilo's page, "Trial use only - do not submit personal or confidential data. Your use is logged for security purposes and to improve NVIDIA products and services."

The verification clause in that footnote needed fixing before it shipped. It said all listed rows were verified with live requests on a single date, and that was not true: the sweep ran on 2026-08-19, only four rows were probed on 2026-08-20, and two listed rows, `poolside/laguna-xs-2.1:free` and `cohere/north-mini-code:free`, had never been probed at all. I probed those two today plus the `kilo-auto/free` router, and all three answered 200 (checks 95, 96 and 97). Every listed Kilo row now has a live-request confirmation, so the footnote says every row listed here answered a live request between 2026-08-19 and 2026-08-21, which is a range and is true.

## ModelScope

Two contexts filled in, both from the model cards, which state "Context Length: 262,144 natively" and carry max_position_embeddings 262144 in config.json.

- `Qwen/Qwen3.5-35B-A3B`: `—` to `256K` (https://modelscope.cn/models/Qwen/Qwen3.5-35B-A3B).
- `Qwen/Qwen3.5-27B`: `—` to `256K` (https://modelscope.cn/models/Qwen/Qwen3.5-27B).

## SiliconFlow

`Qwen/Qwen3-8B` corrected on three fields:

- Rate limit `30 RPM, 60K TPM` to `1,000 RPM, 50,000 TPM`. The per-level table on https://siliconflow.cn/pricing publishes RPM 1000 and TPM 50000, identical at L0 through L5, and https://docs.siliconflow.cn/cn/userguide/rate-limits/rate-limit-and-upgradation says the free models' rate limits are fixed.
- Context `131K` to `128K`. https://siliconflow.cn/models reports contextLen 262144 for other rows and 131072 here, tagged 128K.
- Max output `131K` to `—`. https://docs.siliconflow.cn/cn/api-reference/chat-completions/chat-completions says input and max_tokens share the context window and warns against setting max_tokens to the window's upper bound. There is no separate published max output, so the field is empty rather than a repeat of the context.

Description corrected from "200+ paid models also available" to "100+ models in the catalog, most of them paid". https://siliconflow.cn/models says 100+ mainstream models, and the live catalog reads 88 models of which 16 are free.

`deepseek-ai/DeepSeek-R1-Distill-Qwen-7B` removed, and this is the one item in this PR where I want to be plain about the weakness rather than bury it.

The removal could not be probed. There is no SiliconFlow key here, and the check is recorded as `unprobeable`, `ftk_checks` id 84, 2026-08-20. SiliconFlow has no unauthenticated catalog endpoint either: https://api.siliconflow.cn/v1/models returns 401 "Invalid token", which I verified again today.

So the removal rests on two documentary proofs. First, the dated shutdown announcement at https://docs.siliconflow.cn/cn/release-notes/overview, which I re-read today, 2026-08-21, and which still reads verbatim 平台将于 2026-04-29 对下列模型进行下线处理, followed by a list that includes `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B`. Second, the model's absence from the current catalog on https://siliconflow.cn/pricing and https://siliconflow.cn/models. Anyone who disagrees with the removal should say so, and I will put the row back.

## Aion Labs

Four modality labels normalised. Two of them, `Text (roleplay, reasoning)`, were variants the list does not use anywhere else. The live unauthenticated catalog at https://api.aionlabs.ai/v1/models, re-read today, reports a `reasoning` flag per model, so I used that.

- `aion-labs/aion-2.0`: `Text (roleplay)` to `Text (reasoning)`, catalog `"reasoning": true`.
- `aion-labs/aion-rp-llama-3.1-8b`: `Text (roleplay)` to `Text`, catalog `"reasoning": false`.
- `aion-labs/aion-3.0`: `Text (roleplay, reasoning)` to `Text (reasoning)`, catalog `"reasoning": true`.
- `aion-labs/aion-3.0-mini`: `Text (roleplay, reasoning)` to `Text (reasoning)`, catalog `"reasoning": true`.

The roleplay specialisation is not lost. The entry description already says the provider is specialized for roleplay and storytelling, which is where that belongs.

The same catalog read confirms `expires_at` null on all four, contexts 131072, 131072, 131072 and 32768, and max_completion_tokens 32768 on all four, so the context and max output columns stand as published. The rate limit string is untouched: the published RPM and daily figures have not changed.

## Mistral AI

The entry itself stands. The Free plan card on https://mistral.ai/pricing still reads "$10 /mo in API credits", the subscriptions page still describes a monthly allowance that renews rather than a one-time grant, and the quickstart still says API access is enabled by default with no credit card required. Rate limits are still published nowhere public, so that column is untouched.

One id was wrong. `mistral-medium-2604` does not exist. The model card for Mistral Medium 3.5 at https://docs.mistral.ai/models/mistral-medium-3-5-26-04 publishes `mistral-medium-3-5` and no dated id at all, and `mistral-medium-2604` appears nowhere on Mistral's site. The row now carries `mistral-medium-3-5`. The row's `name` is unchanged, "Mistral Medium 3.5 (128B)", because that is what the README prints and every other Mistral row uses a plain product name rather than an id. So this fix is invisible in the README on purpose. It still matters: `scripts/verify-providers.js` calls the API with `model.id`, so a wrong id makes that row unverifiable. This closes the 2026-08-19 note that the id was unconfirmed. It was not unconfirmed, it was wrong.

Three rows take images and we listed them as text only. https://docs.mistral.ai/studio/conversations/vision has a "Recommended Models with Vision Capabilities" list that names "Ministral 3 14B via ministral-14b-2512", "Ministral 3 8B via ministral-8b-2512" and "Ministral 3 3B via ministral-3b-2512". All three move from `Text` to `Text + Vision`.

This entry has other modality strings that do not match the list's usual vocabulary, "Text + Image + Code" and "Multimodal". I did not audit those tonight, so I left them alone rather than tidy them on a guess.

Footnote 13, two fixes:

- The subscriptions link moved. https://docs.mistral.ai/admin/user-management-finops/subscriptions now 308-redirects to https://docs.mistral.ai/admin/billing-usage/subscriptions, which is the canonical path in the current docs nav. The content still backs the claim word for word: "Each Mistral plan includes monthly usage that is shared across Studio, the API, and Vibe Code."
- The description quotes $10/month in API credits and the footnote had no source for it. The subscriptions page carries no dollar figure at all and defers to the pricing page twice. The only Mistral page that carries the number is the Free plan card on https://mistral.ai/pricing, so the footnote now cites that page for that figure.

## Cloudflare Workers AI

One change. `@cf/google/gemma-4-26b-a4b-it` modality `Text` to `Text + Vision`. The model page at https://developers.cloudflare.com/workers-ai/models/gemma-4-26b-a4b-it/ carries Cloudflare's own capability badges, and Vision is one of them. The catalog index at https://developers.cloudflare.com/workers-ai/models/ lists the id among the vision capable models.

The page also badges Reasoning. The list has no combined value for that, so I left it at `Text + Vision` rather than invent one.

## Checked tonight and deliberately not changed

- **Cohere.** The audit found five documented free model additions and one removal that all look right on paper. None of them ship. The additions need a live confirmation and there is no Cohere key here, and there is no unauthenticated catalog endpoint to fall back on: both https://api.cohere.com/v1/models and https://api.cohere.com/v2/models return 401 "no api key supplied". The removal is an availability claim and needs two independent proofs; I have one and the second has to be a probe I cannot make. Second run in a row it is one proof short.
- **Z AI.** GLM-4.5-Flash is still live and still free. Its announced retirement date is now about seven months past, the row is still in the mainland catalog badged 即将下线, and https://docs.z.ai/guides/overview/pricing.md still prices it Free with no deprecation annotation. So the row keeps its "(retirement announced)" marker and stays listed rather than being pulled. Three documented free Z AI models are blocked on the same missing key. Its 128K / 96K and reasoning modality were re-confirmed.
- **Cloudflare's paid-only exclusion list.** Re-read in full. It still names exactly the same five ids, word for word, and none of them is a row in this list. The 10,000 Neurons/day terms, the base URL, all seven ids and their contexts, and the "+ 72 more models" filler row all reconcile against a catalog of 84 total minus 5 paid-only.

## Checks

`data.json` parses and every entry matches the schema. `scripts/generate-readme.js` runs clean. `awesome-lint` passes on the generated README. The diff touches `data.json` and nothing else.
