### PR TITLE
Add SambaNova Cloud (20 RPM / 20 RPD / 200K TPD, no card)

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-08-21",
+  "lastUpdated": "2026-08-24",
   "providers": [
     {
       "name": "Aion Labs",
@@ -1118,6 +1118,42 @@
       ]
     },
     {
+      "name": "SambaNova Cloud",
+      "category": "inference_provider",
+      "country": "US",
+      "flag": "🇺🇸",
+      "url": "https://cloud.sambanova.ai/apis",
+      "baseUrl": "https://api.sambanova.ai/v1",
+      "description": "Free Tier applies whenever no payment method is linked to the account; linking one moves you to the Developer Tier. No credit card required. OpenAI SDK-compatible.",
+      "footnoteRef": 14,
+      "models": [
+        {
+          "id": "DeepSeek-V3.1",
+          "name": "DeepSeek-V3.1",
+          "context": "131K",
+          "maxOutput": "~7K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200,000 TPD"
+        },
+        {
+          "id": "Meta-Llama-3.3-70B-Instruct",
+          "name": "Meta-Llama-3.3-70B-Instruct",
+          "context": "131K",
+          "maxOutput": "~3K",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200,000 TPD"
+        },
+        {
+          "id": "gpt-oss-120b",
+          "name": "gpt-oss-120b",
+          "context": "131K",
+          "maxOutput": "—",
+          "modality": "Text",
+          "rateLimit": "20 RPM, 20 RPD, 200,000 TPD"
+        }
+      ]
+    },
+    {
       "name": "SiliconFlow",
       "category": "inference_provider",
       "country": "CN",
@@ -1186,6 +1222,10 @@
     {
       "id": 13,
       "text": "Mistral plans are global: the monthly allowance is shared across Studio, the API, and Vibe Code, so CLI usage eats the same budget ([subscriptions](https://docs.mistral.ai/admin/billing-usage/subscriptions)). Free mode is the default for new accounts and needs no credit card ([quickstart](https://docs.mistral.ai/getting-started/quickstarts/studio/activate-and-generate-api-key)), and the Free plan card on the [pricing page](https://mistral.ai/pricing) is what carries the $10/month in API credits figure quoted in the description. Free-mode inputs and outputs may be used to train Mistral models, and you can opt out at any time ([data usage](https://help.mistral.ai/en/articles/347617-do-you-use-my-user-data-to-train-your-artificial-intelligence-models)). Mistral no longer publishes numeric free-tier rate limits and points you at the Limits page of the admin panel instead ([rate limits](https://help.mistral.ai/en/articles/698531-why-am-i-hitting-api-rate-limits-and-how-do-i-increase-them)); the rate limit column is kept from the last published values."
+    },
+    {
+      "id": 14,
+      "text": "SambaNova's Free Tier is defined by the absence of a linked payment method rather than by a time window, and every free model shares the same allowance: 20 RPM, 20 RPD and 200,000 TPD ([rate limits](https://docs.sambanova.ai/docs/en/models/rate-limits)). RPM and RPD are both 20, so one busy minute spends the whole day. Two further models, `DeepSeek-V3.2` (32K context) and `gemma-4-31B-it` (262K context), carry the same free limits but are labelled preview and documented for evaluation only, so they are not listed above. Context and max-output figures come from the public, unauthenticated catalogue at `https://api.sambanova.ai/v1/models`, read 2026-08-24; that endpoint reports `max_completion_tokens` equal to the context length for `gpt-oss-120b`, i.e. no separate output cap, which is why its Max Output is left blank. Linking a payment method moves the account to the Developer Tier (60-240 RPM depending on model), and TPD is tracked for the Free Tier only."
     }
   ],
   "glossary": [


### PR DESCRIPTION
Adds **SambaNova Cloud** to Inference providers. `data.json` only — the README diff above is what CI will regenerate.

### Why it qualifies

| contributing.md rule | this entry |
|---|---|
| Permanent free tier, no trial credits, no time-limited promos | The Free Tier is defined by the **absence of a linked payment method**, not by a clock. Nothing expires. |
| No credit card required to sign up | Correct — adding a card is what *moves you off* the Free Tier, into the Developer Tier. |
| REST API for text inference, not just a playground | OpenAI SDK-compatible at `https://api.sambanova.ai/v1`. |

### Official docs confirming the free tier and its limits

**[SambaNova model rate limits](https://docs.sambanova.ai/docs/en/models/rate-limits)** — the Free Tier
table, quoted verbatim: *"Applied when there is no payment method linked with your account."*
All five free models carry the same allowance:

| Model | RPM | RPD | TPD | status |
|---|---|---|---|---|
| `DeepSeek-V3.1` | 20 | 20 | 200,000 | production |
| `Meta-Llama-3.3-70B-Instruct` | 20 | 20 | 200,000 | production |
| `gpt-oss-120b` | 20 | 20 | 200,000 | production |
| `DeepSeek-V3.2` | 20 | 20 | 200,000 | preview |
| `gemma-4-31B-it` | 20 | 20 | 200,000 | preview |

I listed the three production models in the table and put the two preview ones in the footnote,
since the docs mark those "for evaluation and experimentation, not production".

Context and Max Output are not in the rate-limits page, so I read them from SambaNova's **public,
unauthenticated** catalogue on 2026-08-24 — anyone can re-check this without an account:

```shell
$ curl -s https://api.sambanova.ai/v1/models | jq -r '.data[] | [.id, .context_length, .max_completion_tokens] | @tsv'
DeepSeek-V3.1                   131072  7168
DeepSeek-V3.2                    32768  7168
Meta-Llama-3.3-70B-Instruct     131072  3072
gemma-4-31B-it                  262144  262144
gpt-oss-120b                    131072  131072
MiniMax-M2.7                    ...
MiniMax-M3                      ...
```

`MiniMax-M2.7` and `MiniMax-M3` are served but appear only in the Developer-tier tables, so they
are not in this entry.

### Two things worth flagging rather than hiding

- **`gpt-oss-120b` Max Output is `—`.** The catalogue reports `max_completion_tokens` equal to
  `context_length` for it, which reads as "no separate output cap" rather than a real 131K ceiling.
  Rather than print a number I could not source, I left the cell blank, the way the SiliconFlow row
  does. Same situation for `gemma-4-31B-it`, which is footnote-only anyway.
- **RPM and RPD are both 20.** That is unusual enough to look like a typo, but it is what the table
  says: one busy minute spends the entire day's request budget. I put that sentence in the footnote
  because it changes how you'd actually use this tier.

### What I could not verify

I have not made an authenticated call against the free tier — no account, so no live probe like the
one behind the Kilo Code footnote. Everything above is from SambaNova's published docs and their
public catalogue endpoint, both linked. If you want a live confirmation before merging, that part
is not something I can supply.
