### PR TITLE
Add TideLink — free GLM-4-Flash & GLM-4V-Flash (OpenAI-compatible gateway)

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-08-21",
+  "lastUpdated": "2026-09-10",
   "providers": [
     {
       "name": "Aion Labs",
@@ -1134,6 +1134,34 @@
           "maxOutput": "—",
           "modality": "Text",
           "rateLimit": "1,000 RPM, 50,000 TPM"
+        }
+      ]
+    },
+    {
+      "name": "TideLink",
+      "category": "inference_provider",
+      "country": "CN",
+      "flag": "🇨🇳",
+      "url": "https://tidelink.xyz/dashboard.html",
+      "baseUrl": "https://tidelink.xyz/v1",
+      "description": "Free tier, no credit card required. GLM-4-Flash and GLM-4V-Flash are free with a 10 RPM limit. OpenAI-compatible gateway that aggregates GLM, Qwen, DeepSeek, Hunyuan and Doubao behind a single API key.",
+      "footnoteRef": null,
+      "models": [
+        {
+          "id": "glm-4-flash",
+          "name": "glm-4-flash",
+          "context": "128K",
+          "maxOutput": "—",
+          "modality": "Text",
+          "rateLimit": "10 RPM"
+        },
+        {
+          "id": "glm-4v-flash",
+          "name": "glm-4v-flash",
+          "context": "16K",
+          "maxOutput": "—",
+          "modality": "Text + Vision",
+          "rateLimit": "10 RPM"
         }
       ]
     }


### PR DESCRIPTION
Adds **TideLink**, an OpenAI-compatible gateway that aggregates Chinese LLMs (GLM, Qwen, DeepSeek, Hunyuan, Doubao) behind one API key.

**Free tier** (no credit card required):
- `glm-4-flash` — 128K context, free
- `glm-4v-flash` — vision, 16K context, free
- Rate limit: 10 requests/min; base URL `https://tidelink.xyz/v1`

Evidence for the free tier: the public pricing page lists GLM-4-Flash at $0.00 and states "GLM-4-Flash is free" — https://tidelink.xyz/pricing.html . The models are served from a permanently free upstream (Zhipu free tier), and free-tier keys are restricted to exactly these two models.

Signup / API key page: https://tidelink.xyz/dashboard.html

*Disclosure: I am affiliated with TideLink (operator submission).*